### PR TITLE
Murisi/fresh algos

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -550,8 +550,8 @@ impl InfixOp {
             "+" => Some(Self::Add),
             "-" => Some(Self::Subtract),
             "^" => Some(Self::Exponentiate),
-            // IntDivide and Modulo purposefully not included in the source
-            // language due to their inefficiency
+            "\\" => Some(Self::IntDivide),
+            "%" => Some(Self::Modulo),
             _ => unreachable!("Encountered unknown infix operator")
         }
     }
@@ -566,8 +566,8 @@ impl fmt::Display for InfixOp {
             Self::Subtract => write!(f, "-"),
             Self::Equal => write!(f, "="),
             Self::Exponentiate => write!(f, "^"),
-            Self::IntDivide => write!(f, "//"),
-            Self::Modulo => write!(f, " mod "),
+            Self::IntDivide => write!(f, "\\"),
+            Self::Modulo => write!(f, "%"),
         }
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -870,7 +870,7 @@ pub fn compile(mut module: Module) -> Module {
     let mut globals = HashMap::new();
     let mut bindings = HashMap::new();
     let mut prog_types = HashMap::new();
-    register_range_intrinsic(&mut globals, &mut bindings, &mut prog_types, &mut vg);
+    register_fresh_intrinsic(&mut globals, &mut bindings, &mut prog_types, &mut vg);
     number_module_variables(&mut module, &mut globals, &mut vg);
     infer_module_types(&mut module, &globals, &mut prog_types, &mut vg);
     println!("** Inferring types...");
@@ -1037,153 +1037,57 @@ pub fn eliminate_dead_definitions(module: &mut Module) {
     module.defs = new_defs;
 }
 
-/* The number of bits required to represent elements of the field we are working
- * in. */
-const RANGE_MAX_BITS: u32 = 16;
-
-/* Register the range intrinsic in the compilation environment. */
-fn register_range_intrinsic(
+/* Register the fresh intrinsic in the compilation environment. */
+fn register_fresh_intrinsic(
     globals: &mut HashMap<String, VariableId>,
     bindings: &mut HashMap<VariableId, TExpr>,
     types: &mut HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
-    let range_func_id = gen.generate_id();
+    let fresh_func_id = gen.generate_id();
+    let fresh_arg = Type::Variable(Variable::new(gen.generate_id()));
     // Register the range function in global namespace
-    globals.insert("range".to_string(), range_func_id);
-    // Make the type representing largest bit vector
-    let mut bits_type = Type::Unit;
-    for _ in 0..RANGE_MAX_BITS {
-        bits_type = Type::Product(Box::new(Type::Int), Box::new(bits_type));
-    }
+    globals.insert("fresh".to_string(), fresh_func_id);
     // Describe the intrinsic's type, arity, and implementation
-    let range_intrinsic = Intrinsic::new(
-        2,
+    let fresh_intrinsic = Intrinsic::new(
+        1,
         Type::Function(
-            Box::new(Type::Int),
-            Box::new(Type::Function(
-                Box::new(Type::Int),
-                Box::new(bits_type),
-            ))
+            Box::new(fresh_arg.clone()),
+            Box::new(fresh_arg),
         ),
-        expand_range_intrinsic,
+        expand_fresh_intrinsic,
     );
     // Register the intrinsic descriptor with the global binding
-    types.insert(range_func_id, range_intrinsic.imp_typ.clone());
-    bindings.insert(range_func_id, Expr::Intrinsic(range_intrinsic).into());
+    types.insert(fresh_func_id, fresh_intrinsic.imp_typ.clone());
+    bindings.insert(fresh_func_id, Expr::Intrinsic(fresh_intrinsic).into());
 }
 
-/* Expand a range call into a series of constraints that force the value
- * argument to be the given number of bits. */
-fn expand_range_intrinsic(
+/* fresh x returns a fresh unconstrained variable whose prover definition equals
+ * the supplied expression. */
+fn expand_fresh_intrinsic(
     args: &Vec<TExpr>,
     _bindings: &HashMap<VariableId, TExpr>,
     prover_defs: &mut HashSet<VariableId>,
     gen: &mut VarGen,
 ) -> TExpr {
-    if let [TExpr { v: Expr::Constant(bit_len), ..}, val] = &args[..] {
-        let mut constraints = vec![];
-        let mut bit_bindings = HashMap::new();
-        let mut val_constraint = TExpr { v: Expr::Constant(0), t: None };
-        let mut witnesses = TExpr { v: Expr::Unit, t: Some(Type::Unit) };
-        // Constrain the variables involved in this expansion to be bits
-        let bit_len = u32::try_from(*bit_len)
-            .expect("bit count supplied to range must be non-negative");
-        // Put trailing zeros into bit-vector
-        for _ in bit_len..RANGE_MAX_BITS {
-            witnesses = TExpr {
-                v: Expr::Product(
-                    Box::new(TExpr { v: Expr::Constant(0), t: Some(Type::Int) }),
-                    Box::new(witnesses.clone())
+    if let [val] = &args[..] {
+        // Make a new prover definition that is equal to the argument
+        let fresh_arg = Variable::new(gen.generate_id());
+        prover_defs.insert(fresh_arg.id);
+        TExpr {
+            t: val.t.clone(),
+            v: Expr::LetBinding(
+                LetBinding(
+                    Pattern::Variable(fresh_arg.clone()),
+                    Box::new(val.clone()),
                 ),
-                t: Some(Type::Product(
-                    Box::new(Type::Int),
-                    Box::new(witnesses.t.unwrap())
-                )),
-            };
+                Box::new(TExpr {
+                    t: val.t.clone(),
+                    v: Expr::Variable(fresh_arg)
+                })
+            ),
         }
-        for i in (0..bit_len).rev() {
-            // expression: b
-            let bit_var = gen.generate_id();
-            // do not put the explicit definition of this variable into circuit
-            prover_defs.insert(bit_var);
-            // definition: b = (val // (2^i)) mod 2
-            let explicit_val = infix_op(
-                InfixOp::Modulo,
-                infix_op(
-                    InfixOp::IntDivide,
-                    val.clone(),
-                    TExpr { v: Expr::Constant(2i32.pow(i)), t: Some(Type::Int) }
-                ),
-                TExpr { v: Expr::Constant(2), t: Some(Type::Int) }
-            );
-            bit_bindings.insert(bit_var, explicit_val);
-            // expression: b
-            let bit_var = Expr::Variable(Variable::new(bit_var));
-            let bit_var = TExpr { v: bit_var, t: Some(Type::Int) };
-            // expression: b-1
-            let bit_var_m1 = infix_op(
-                InfixOp::Subtract,
-                bit_var.clone(),
-                TExpr { v: Expr::Constant(1), t: Some(Type::Int) }
-            );
-            // expression: val_constraint := 2*val_constraint + b
-            val_constraint = infix_op(
-                InfixOp::Add,
-                bit_var.clone(),
-                infix_op(
-                    InfixOp::Multiply,
-                    TExpr { v: Expr::Constant(2), t: Some(Type::Int) },
-                    val_constraint,
-                ),
-            );
-            // constraint: b*(b-1) = 0
-            constraints.push(infix_op(
-                InfixOp::Equal,
-                infix_op(
-                    InfixOp::Multiply,
-                    bit_var.clone(),
-                    bit_var_m1,
-                ),
-                TExpr { v: Expr::Constant(0), t: Some(Type::Int) },
-            ));
-            // Record bit index and value for the coming array creation
-            witnesses = TExpr {
-                v: Expr::Product(Box::new(bit_var), Box::new(witnesses.clone())),
-                t: Some(Type::Product(Box::new(Type::Int), Box::new(witnesses.t.unwrap()))),
-            };
-        }
-        // constraint: val = 2*(2*(2*(..) + b_2) + b_1) + b_0
-        // Uses Horner's method.
-        constraints.push(infix_op(
-            InfixOp::Equal,
-            val_constraint,
-            val.clone(),
-        ));
-        // expression: (b0, b1, ..., bN)
-        constraints.push(witnesses.clone());
-        // The aggregate of the above constraints constrains the given value to
-        // be the given number of bits
-        let mut constraint = TExpr {
-            v: Expr::Sequence(constraints),
-            t: witnesses.t,
-        };
-        // To help the prover derive the bit assignments, surround the
-        // constraints with explicit definitions
-        for (bit_var, explicit_var) in bit_bindings {
-            constraint = TExpr {
-                t: constraint.t.clone(),
-                v: Expr::LetBinding(
-                    LetBinding(
-                        Pattern::Variable(Variable::new(bit_var)),
-                        Box::new(explicit_var),
-                    ),
-                    Box::new(constraint)
-                ),
-            };
-        }
-        constraint
     } else {
-        panic!("unexpected arguments to range: {:?}", args);
+        panic!("unexpected arguments to fresh: {:?}", args);
     }
 }

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -8,7 +8,7 @@ keyword = { "fun" | "def" }
 
 valueName = { !keyword ~ lowercaseIdent }
 
-infixOp = { "/" | "*" | "+" | "-" | "=" | "^" }
+infixOp = { "/" | "*" | "+" | "-" | "=" | "^" | "\\" | "%" }
 
 integerLiteral = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
 
@@ -32,7 +32,7 @@ expr3 = { expr4 ~ ( &"=" ~ infixOp ~ expr4 )* }
 
 expr4 = { expr5 ~ ( &("+" | "-") ~ infixOp ~ expr5 )* }
 
-expr5 = { expr6 ~ ( &("*" | "/") ~ infixOp ~ expr6 )* }
+expr5 = { expr6 ~ ( &("*" | "/" | "\\" | "%") ~ infixOp ~ expr6 )* }
 
 expr6 = { expr7 ~ ( &"^" ~ infixOp ~ expr7 )* }
 

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -10,36 +10,37 @@
 
 def bool x { x*(x-1) = 0; x };
 
-// Extract the 8 bits from a number argument
+// Extract the n+1 bits from a number argument
+// given a range function for n bits
 
-def range8 a {
-    def a0 = bool (fresh ((a\1) % 2));
-    def a1 = bool (fresh ((a\2) % 2));
-    def a2 = bool (fresh ((a\4) % 2));
-    def a3 = bool (fresh ((a\8) % 2));
-    def a4 = bool (fresh ((a\16) % 2));
-    def a5 = bool (fresh ((a\32) % 2));
-    def a6 = bool (fresh ((a\64) % 2));
-    def a7 = bool (fresh ((a\128) % 2));
-    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7;
-    (a0, a1, a2, a3, a4, a5, a6, a7, ())
+def next_range range a {
+    def a0 = bool (fresh (a%2));
+    def a1 = fresh (a\2);
+    a = a0 + 2*a1;
+    (a0, range a1)
 };
 
-// Extract the 9 bits from a number argument
+// Inductively define range for each bit width
 
-def range9 a {
-    def a0 = bool (fresh ((a\1) % 2));
-    def a1 = bool (fresh ((a\2) % 2));
-    def a2 = bool (fresh ((a\4) % 2));
-    def a3 = bool (fresh ((a\8) % 2));
-    def a4 = bool (fresh ((a\16) % 2));
-    def a5 = bool (fresh ((a\32) % 2));
-    def a6 = bool (fresh ((a\64) % 2));
-    def a7 = bool (fresh ((a\128) % 2));
-    def a8 = bool (fresh ((a\256) % 2));
-    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7 + 256*a8;
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, ())
-};
+def range0 0 { () };
+
+def range1 = next_range range0;
+
+def range2 = next_range range1;
+
+def range3 = next_range range2;
+
+def range4 = next_range range3;
+
+def range5 = next_range range4;
+
+def range6 = next_range range5;
+
+def range7 = next_range range6;
+
+def range8 = next_range range7;
+
+def range9 = next_range range8;
 
 // Pair up corresponding elements of each tuple
 
@@ -232,3 +233,5 @@ def rem a b { snd (divrem a b) };
 1 = sle8 5 5;
 
 (4,1) = divrem 9 2;
+
+range4 15;

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -6,6 +6,58 @@
    vamp-ir verify circuit.plonk params.pp proof.plonk
 */
 
+// Ensure that the given argument is 1 or 0
+
+def bool x { x*(x-1) = 0 };
+
+// Extract the 8 bits from a number argument
+
+def range8 a {
+    def a0 = fresh ((a\1) % 2);
+    def a1 = fresh ((a\2) % 2);
+    def a2 = fresh ((a\4) % 2);
+    def a3 = fresh ((a\8) % 2);
+    def a4 = fresh ((a\16) % 2);
+    def a5 = fresh ((a\32) % 2);
+    def a6 = fresh ((a\64) % 2);
+    def a7 = fresh ((a\128) % 2);
+    bool a0;
+    bool a1;
+    bool a2;
+    bool a3;
+    bool a4;
+    bool a5;
+    bool a6;
+    bool a7;
+    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7;
+    (a0, a1, a2, a3, a4, a5, a6, a7, ())
+};
+
+// Extract the 9 bits from a number argument
+
+def range9 a {
+    def a0 = fresh ((a\1) % 2);
+    def a1 = fresh ((a\2) % 2);
+    def a2 = fresh ((a\4) % 2);
+    def a3 = fresh ((a\8) % 2);
+    def a4 = fresh ((a\16) % 2);
+    def a5 = fresh ((a\32) % 2);
+    def a6 = fresh ((a\64) % 2);
+    def a7 = fresh ((a\128) % 2);
+    def a8 = fresh ((a\256) % 2);
+    bool a0;
+    bool a1;
+    bool a2;
+    bool a3;
+    bool a4;
+    bool a5;
+    bool a6;
+    bool a7;
+    bool a8;
+    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7 + 256*a8;
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, ())
+};
+
 // Pair up corresponding elements of each tuple
 
 def zip8 (a0,a1,a2,a3,a4,a5,a6,a7,ar) (b0,b1,b2,b3,b4,b5,b6,b7,br) {
@@ -27,7 +79,7 @@ def combine8 (a0,a1,a2,a3,a4,a5,a6,a7,ar) {
 // Apply given function to corresponding bit-pairs in bit representation
 
 def bitwise8 g a b {
-    def zipped = zip8 (range 8 a) (range 8 b);
+    def zipped = zip8 (range8 a) (range8 b);
     def new_bits = map g zipped;
     combine8 new_bits
 };
@@ -58,7 +110,7 @@ def and8 = bitwise8 bit_and;
 
 // Definition of bitwise not for 8 bit values
 
-def not8 y { combine8 (map (fun x { 1-x }) (range 8 y)) };
+def not8 y { combine8 (map (fun x { 1-x }) (range8 y)) };
 
 // Repeated function applications, useful for big-step rotations/shifts
 
@@ -81,56 +133,56 @@ def apply7 f x { f (apply6 f x) };
 // Arithmetic shift right for 8 bit values
 
 def ashr8 x {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range 8 x;
+    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a1, a2, a3, a4, a5, a6, a7, a7, ())
 };
 
 // Logical shift right for 8 bit values
 
 def lshr8 x {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range 8 x;
+    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a1, a2, a3, a4, a5, a6, a7, 0, ())
 };
 
 // Shift left for 8 bit values
 
 def shl8 x {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range 8 x;
+    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (0, a0, a1, a2, a3, a4, a5, a6, ())
 };
 
 // Rotate right for 8 bit values
 
 def ror8 x {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range 8 x;
+    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a1, a2, a3, a4, a5, a6, a7, a0, ())
 };
 
 // Rotate left for 8 bit values
 
 def rol8 x {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range 8 x;
+    def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a7, a0, a1, a2, a3, a4, a5, a6, ())
 };
 
 // Add two 8-bit values modulo 8
 
 def add8 a b {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,ar) = range 9 (a+b);
+    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,ar) = range9 (a+b);
     combine8 (a0, a1, a2, a3, a4, a5, a6, a7, ())
 };
 
 // Subtract two 8-bit values modulo 8
 
 def sub8 a b {
-    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,ar) = range 9 (a+256-b);
+    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,ar) = range9 (a+256-b);
     combine8 (a0, a1, a2, a3, a4, a5, a6, a7, ())
 };
 
 // Unsigned less than or equal to for 8 bits. 1 if true, 0 otherwise
 
 def ule8 a b {
-    def (c0,c1,c2,c3,c4,c5,c6,c7,c8, ar) = range 9 (256+b-a);
+    def (c0,c1,c2,c3,c4,c5,c6,c7,c8, ar) = range9 (256+b-a);
     c8
 };
 
@@ -141,7 +193,7 @@ def ult8 a b { ule8 a (b-1) };
 // Signed less than or equal to for 8 bits
 
 def slt8 a b {
-    def (c0,c1,c2,c3,c4,c5,c6,c7,c8,ar) = range 9 (a+256-b);
+    def (c0,c1,c2,c3,c4,c5,c6,c7,c8,ar) = range9 (a+256-b);
     c7
 };
 

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -6,29 +6,21 @@
    vamp-ir verify circuit.plonk params.pp proof.plonk
 */
 
-// Ensure that the given argument is 1 or 0
+// Ensure that the given argument is 1 or 0, and returns it
 
-def bool x { x*(x-1) = 0 };
+def bool x { x*(x-1) = 0; x };
 
 // Extract the 8 bits from a number argument
 
 def range8 a {
-    def a0 = fresh ((a\1) % 2);
-    def a1 = fresh ((a\2) % 2);
-    def a2 = fresh ((a\4) % 2);
-    def a3 = fresh ((a\8) % 2);
-    def a4 = fresh ((a\16) % 2);
-    def a5 = fresh ((a\32) % 2);
-    def a6 = fresh ((a\64) % 2);
-    def a7 = fresh ((a\128) % 2);
-    bool a0;
-    bool a1;
-    bool a2;
-    bool a3;
-    bool a4;
-    bool a5;
-    bool a6;
-    bool a7;
+    def a0 = bool (fresh ((a\1) % 2));
+    def a1 = bool (fresh ((a\2) % 2));
+    def a2 = bool (fresh ((a\4) % 2));
+    def a3 = bool (fresh ((a\8) % 2));
+    def a4 = bool (fresh ((a\16) % 2));
+    def a5 = bool (fresh ((a\32) % 2));
+    def a6 = bool (fresh ((a\64) % 2));
+    def a7 = bool (fresh ((a\128) % 2));
     a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7;
     (a0, a1, a2, a3, a4, a5, a6, a7, ())
 };
@@ -36,24 +28,15 @@ def range8 a {
 // Extract the 9 bits from a number argument
 
 def range9 a {
-    def a0 = fresh ((a\1) % 2);
-    def a1 = fresh ((a\2) % 2);
-    def a2 = fresh ((a\4) % 2);
-    def a3 = fresh ((a\8) % 2);
-    def a4 = fresh ((a\16) % 2);
-    def a5 = fresh ((a\32) % 2);
-    def a6 = fresh ((a\64) % 2);
-    def a7 = fresh ((a\128) % 2);
-    def a8 = fresh ((a\256) % 2);
-    bool a0;
-    bool a1;
-    bool a2;
-    bool a3;
-    bool a4;
-    bool a5;
-    bool a6;
-    bool a7;
-    bool a8;
+    def a0 = bool (fresh ((a\1) % 2));
+    def a1 = bool (fresh ((a\2) % 2));
+    def a2 = bool (fresh ((a\4) % 2));
+    def a3 = bool (fresh ((a\8) % 2));
+    def a4 = bool (fresh ((a\16) % 2));
+    def a5 = bool (fresh ((a\32) % 2));
+    def a6 = bool (fresh ((a\64) % 2));
+    def a7 = bool (fresh ((a\128) % 2));
+    def a8 = bool (fresh ((a\256) % 2));
     a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7 + 256*a8;
     (a0, a1, a2, a3, a4, a5, a6, a7, a8, ())
 };

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -6,23 +6,18 @@
    vamp-ir verify circuit.plonk params.pp proof.plonk
 */
 
-// Ensure that the given argument is 1 or 0
+// Ensure that the given argument is 1 or 0, and returns it
 
-def bool x { x*(x-1) = 0 };
+def bool x { x*(x-1) = 0; x };
 
 // Extract the 8 bits from a number argument
 
 def range5 a {
-    def a0 = fresh ((a\1) % 2);
-    def a1 = fresh ((a\2) % 2);
-    def a2 = fresh ((a\4) % 2);
-    def a3 = fresh ((a\8) % 2);
-    def a4 = fresh ((a\16) % 2);
-    bool a0;
-    bool a1;
-    bool a2;
-    bool a3;
-    bool a4;
+    def a0 = bool (fresh ((a\1) % 2));
+    def a1 = bool (fresh ((a\2) % 2));
+    def a2 = bool (fresh ((a\4) % 2));
+    def a3 = bool (fresh ((a\8) % 2));
+    def a4 = bool (fresh ((a\16) % 2));
     a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4;
     (a0, a1, a2, a3, a4, ())
 };

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -5,4 +5,26 @@
    vamp-ir prove circuit.plonk params.pp proof.plonk
    vamp-ir verify circuit.plonk params.pp proof.plonk
 */
-def (0, 1, ar) = range 5 x;
+
+// Ensure that the given argument is 1 or 0
+
+def bool x { x*(x-1) = 0 };
+
+// Extract the 8 bits from a number argument
+
+def range5 a {
+    def a0 = fresh ((a\1) % 2);
+    def a1 = fresh ((a\2) % 2);
+    def a2 = fresh ((a\4) % 2);
+    def a3 = fresh ((a\8) % 2);
+    def a4 = fresh ((a\16) % 2);
+    bool a0;
+    bool a1;
+    bool a2;
+    bool a3;
+    bool a4;
+    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4;
+    (a0, a1, a2, a3, a4, ())
+};
+
+def (0, 1, ar) = range5 x;


### PR DESCRIPTION
Functions like Euclidean division have the property that they are easy to compute but have relatively large arithmetic circuits. The following proposed changes essentially allow Vampir programs to provide/override the set of constraints that should/would be generated for a particular program expression.

More specifically, the changes do the following:
* Introduced the builtin `fresh: x -> x`, which returns a new unconstrained variable equal to the argument w.r.t. the prover
* Removed the `range` builtin, since for each given bit-width it can be defined in terms of `fresh`
* Introduced Euclidean division operators `\` and `%`, these cannot be used to constrain variable values as they are too expensive
* Made an example demonstrating the definition of `range5` in terms of `fresh`, `\`, and `%`
* Made another example demonstrating inductive definitions of `range` functions

The disadvantage of the chosen approach is that users can potentially override an expression with consraints that do not uniquely identify its value. I.e. there could be other proof values that still satisfy the same constraints, or some expression values may not satisfy the supplied constraints. The risks of this might potentially be mitigated by use of an SMT solver or random testing.

Another disadvantage of the chosen approach in the context of Vampir's current features and type-system, is that a `range` function must be separately defined for each bit-width. It seems that a general `range` would require lists in order to be implemented.

A better name for `fresh` might be `new`...