### PR TITLE
Made def syntax more regular.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -75,30 +75,7 @@ impl Definition {
 
 impl fmt::Display for Definition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Expr::Function(Function(params, body)) = &self.0.1.v {
-            write!(f, "def {}", self.0.0)?;
-            for param in params {
-                write!(f, " {}", param)?;
-            }
-            let mut body_str = String::new();
-            write!(body_str, "{}", body)?;
-            if body_str.contains("\n") {
-                body_str = body_str.replace("\n", "\n    ");
-                write!(f, " =\n    {}", body_str)?
-            } else {
-                write!(f, " = {}", body_str)?
-            }
-        } else {
-            let mut val_str = String::new();
-            write!(val_str, "{}", self.0.1)?;
-            if val_str.contains("\n") {
-                val_str = val_str.replace("\n", "\n    ");
-                write!(f, "def {} =\n    {}", self.0.0, val_str)?
-            } else {
-                write!(f, "def {} = {}", self.0.0, val_str)?
-            }
-        }
-        Ok(())
+        write!(f, "def {}", self.0)
     }
 }
 
@@ -136,21 +113,30 @@ impl LetBinding {
 impl fmt::Display for LetBinding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.1.v {
-            Expr::Function(fun) => {
+            Expr::Function(Function(params, body)) => {
                 write!(f, "{}", self.0)?;
-                for pat in &fun.0 {
+                for pat in params {
                     write!(f, " {}", pat)?;
                 }
                 write!(f, " =")?;
-                let mut body = String::new();
-                write!(body, "{}", fun.1)?;
-                if body.contains("\n") {
-                    write!(f, "\n    {}", body.replace("\n", "\n    "))?;
+                let mut body_str = String::new();
+                write!(body_str, "{}", body)?;
+                if body_str.contains("\n") {
+                    write!(f, "\n    {}", body_str.replace("\n", "\n    "))?;
                 } else {
                     write!(f, " {}", body)?;
                 }
             },
-            _ => write!(f, "{} = {}", self.0, self.1)?,
+            _ => {
+                let mut val_str = String::new();
+                write!(val_str, "{}", self.1)?;
+                if val_str.contains("\n") {
+                    let val_str = val_str.replace("\n", "\n    ");
+                    write!(f, "{} =\n    {}", self.0, val_str)?;
+                } else {
+                    write!(f, "{} = {}", self.0, val_str)?;
+                }
+            },
         };
         Ok(())
     }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -782,6 +782,10 @@ where
     }
 
     fn padded_circuit_size(&self) -> usize {
-        self.module.exprs.len().next_power_of_two()
+        // The with_expected_size function adds the following gates:
+        // 1 gate to constrain the zero variable to equal 0
+        // 3 gates to add blinging factors to the circuit polynomials
+        const BUILTIN_GATE_COUNT: usize = 4;
+        (self.module.exprs.len()+BUILTIN_GATE_COUNT).next_power_of_two()
     }
 }

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -20,9 +20,9 @@ pattern1 = { pattern2 ~ ( "," ~ pattern2 )* }
 
 pattern2 = { valueName | constant | "(" ~ pattern ~ ")" }
 
-letBinding = { pattern ~ "=" ~ expr | valueName ~ pattern* ~ &"{" ~ expr }
+letBinding = { pattern ~ "=" ~ expr | valueName ~ pattern* ~ "=" ~ expr }
 
-expr = { function | "def" ~ letBinding ~ ( ";" ~ expr )+ | expr1 }
+expr = { function | "def" ~ letBinding ~ ( ";" ~ expr )+ | !("def" | "fun") ~ expr1 }
 
 expr1 = { expr2 | "{" ~ expr2 ~ ( ";" ~ expr2 )* ~ "}" }
 

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -8,12 +8,12 @@
 
 // Ensure that the given argument is 1 or 0, and returns it
 
-def bool x { x*(x-1) = 0; x };
+def bool x = { x*(x-1) = 0; x };
 
 // Extract the n+1 bits from a number argument
 // given a range function for n bits
 
-def next_range range a {
+def next_range range a = {
     def a0 = bool (fresh (a%2));
     def a1 = fresh (a\2);
     a = a0 + 2*a1;
@@ -22,7 +22,7 @@ def next_range range a {
 
 // Inductively define range for each bit width
 
-def range0 0 { () };
+def range0 0 = ();
 
 def range1 = next_range range0;
 
@@ -44,25 +44,22 @@ def range9 = next_range range8;
 
 // Pair up corresponding elements of each tuple
 
-def zip8 (a0,a1,a2,a3,a4,a5,a6,a7,ar) (b0,b1,b2,b3,b4,b5,b6,b7,br) {
-    ((a0,b0),(a1,b1),(a2,b2),(a3,b3),(a4,b4),(a5,b5),(a6,b6),(a7,b7),())
-};
+def zip8 (a0,a1,a2,a3,a4,a5,a6,a7,ar) (b0,b1,b2,b3,b4,b5,b6,b7,br) =
+    ((a0,b0),(a1,b1),(a2,b2),(a3,b3),(a4,b4),(a5,b5),(a6,b6),(a7,b7),());
 
 // Apply function to each element of tuple
 
-def map f (g0,g1,g2,g3,g4,g5,g6,g7,gr) {
-    (f g0, f g1, f g2, f g3, f g4, f g5, f g6, f g7, ())
-};
+def map f (g0,g1,g2,g3,g4,g5,g6,g7,gr) =
+    (f g0, f g1, f g2, f g3, f g4, f g5, f g6, f g7, ());
 
 // Multiply each tuple element by corresponding unit
 
-def combine8 (a0,a1,a2,a3,a4,a5,a6,a7,ar) {
-    a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7
-};
+def combine8 (a0,a1,a2,a3,a4,a5,a6,a7,ar) =
+    a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7;
 
 // Apply given function to corresponding bit-pairs in bit representation
 
-def bitwise8 g a b {
+def bitwise8 g a b = {
     def zipped = zip8 (range8 a) (range8 b);
     def new_bits = map g zipped;
     combine8 new_bits
@@ -70,7 +67,7 @@ def bitwise8 g a b {
 
 // Definition of xor for domain {0, 1}^2
 
-def bit_xor (a,b) { a*(1-b)+(1-a)*b };
+def bit_xor (a,b) = a*(1-b)+(1-a)*b;
 
 // Definition of bitwise xor for 8 bit values
 
@@ -78,7 +75,7 @@ def xor8 = bitwise8 bit_xor;
 
 // Definition of or for domain {0, 1}^2
 
-def bit_or (a,b) { a + b - a*b };
+def bit_or (a,b) = a + b - a*b;
 
 // Definition of bitwise or for 8 bit values
 
@@ -86,7 +83,7 @@ def or8 = bitwise8 bit_or;
 
 // Definition of and for domain {0, 1}^2
 
-def bit_and (a,b) { a*b };
+def bit_and (a,b) = a*b;
 
 // Definition of bitwise and for 8 bit values
 
@@ -94,108 +91,108 @@ def and8 = bitwise8 bit_and;
 
 // Definition of bitwise not for 8 bit values
 
-def not8 y { combine8 (map (fun x { 1-x }) (range8 y)) };
+def not8 y = combine8 (map (fun x { 1-x }) (range8 y));
 
 // Repeated function applications, useful for big-step rotations/shifts
 
-def apply0 f x { x };
+def apply0 f x = x;
 
-def apply1 f x { f (apply0 f x) };
+def apply1 f x = f (apply0 f x);
 
-def apply2 f x { f (apply1 f x) };
+def apply2 f x = f (apply1 f x);
 
-def apply3 f x { f (apply2 f x) };
+def apply3 f x = f (apply2 f x);
 
-def apply4 f x { f (apply3 f x) };
+def apply4 f x = f (apply3 f x);
 
-def apply5 f x { f (apply4 f x) };
+def apply5 f x = f (apply4 f x);
 
-def apply6 f x { f (apply5 f x) };
+def apply6 f x = f (apply5 f x);
 
-def apply7 f x { f (apply6 f x) };
+def apply7 f x = f (apply6 f x);
 
 // Arithmetic shift right for 8 bit values
 
-def ashr8 x {
+def ashr8 x = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a1, a2, a3, a4, a5, a6, a7, a7, ())
 };
 
 // Logical shift right for 8 bit values
 
-def lshr8 x {
+def lshr8 x = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a1, a2, a3, a4, a5, a6, a7, 0, ())
 };
 
 // Shift left for 8 bit values
 
-def shl8 x {
+def shl8 x = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (0, a0, a1, a2, a3, a4, a5, a6, ())
 };
 
 // Rotate right for 8 bit values
 
-def ror8 x {
+def ror8 x = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a1, a2, a3, a4, a5, a6, a7, a0, ())
 };
 
 // Rotate left for 8 bit values
 
-def rol8 x {
+def rol8 x = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,ar) = range8 x;
     combine8 (a7, a0, a1, a2, a3, a4, a5, a6, ())
 };
 
 // Add two 8-bit values modulo 8
 
-def add8 a b {
+def add8 a b = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,a8,ar) = range9 (a+b);
     combine8 (a0, a1, a2, a3, a4, a5, a6, a7, ())
 };
 
 // Subtract two 8-bit values modulo 8
 
-def sub8 a b {
+def sub8 a b = {
     def (a0,a1,a2,a3,a4,a5,a6,a7,a8,ar) = range9 (a+256-b);
     combine8 (a0, a1, a2, a3, a4, a5, a6, a7, ())
 };
 
 // Unsigned less than or equal to for 8 bits. 1 if true, 0 otherwise
 
-def ule8 a b {
+def ule8 a b = {
     def (c0,c1,c2,c3,c4,c5,c6,c7,c8, ar) = range9 (256+b-a);
     c8
 };
 
 // Unsigned less than for 8 bits
 
-def ult8 a b { ule8 a (b-1) };
+def ult8 a b = ule8 a (b-1);
 
 // Signed less than or equal to for 8 bits
 
-def slt8 a b {
+def slt8 a b = {
     def (c0,c1,c2,c3,c4,c5,c6,c7,c8,ar) = range9 (a+256-b);
     c7
 };
 
 // Signed less than for 8 bits
 
-def sle8 a b { slt8 a (b+1) };
+def sle8 a b = slt8 a (b+1);
 
 // Extract the first element of any supplied pair
 
-def fst (a,b) { a };
+def fst (a,b) = a;
 
 // Extract the second element of any supplied pair
 
-def snd (a,b) { b };
+def snd (a,b) = b;
 
 // 4 bit unsigned Euclidean division
 
-def divrem a3 b0 {
+def divrem a3 b0 = {
     def b1 = b0*2;
     def b2 = b1*2;
     def b3 = b2*2;
@@ -210,9 +207,9 @@ def divrem a3 b0 {
     (combine8 (c0, c1, c2, c3, 0, 0, 0, 0, ()), rem)
 };
 
-def div a b { fst (divrem a b) };
+def div a b = fst (divrem a b);
 
-def rem a b { snd (divrem a b) };
+def rem a b = snd (divrem a b);
 
 // Check the operations work correctly
 

--- a/tests/bool.pir
+++ b/tests/bool.pir
@@ -9,7 +9,7 @@ def myval = 0;
 // constraint expression
 myval = 0;
 // defining a function
-def bool x { x*(x-1) = 0 };
+def bool x = { x*(x-1) = 0 };
 // calling a function
 bool 1;
 // solicit a user input

--- a/tests/funcs.pir
+++ b/tests/funcs.pir
@@ -6,7 +6,7 @@
    */
 // defining a two parameter function.
 // function body contains two constraints.
-def myeq a b { a = b; b = a };
+def myeq a b = { a = b; b = a };
 // solicit equal user inputs
 myeq b c;
 // currying example

--- a/tests/pyt.pir
+++ b/tests/pyt.pir
@@ -5,7 +5,7 @@
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
    */
 // computation + BIDMAS
-def pyt a b { a^2 + b^2 };
+def pyt a b = a^2 + b^2;
 // constrain computation
 pyt x y = 25;
 // let bindings

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -8,11 +8,11 @@
 
 // Ensure that the given argument is 1 or 0, and returns it
 
-def bool x { x*(x-1) = 0; x };
+def bool x = { x*(x-1) = 0; x };
 
 // Extract the 8 bits from a number argument
 
-def range5 a {
+def range5 a = {
     def a0 = bool (fresh ((a\1) % 2));
     def a1 = bool (fresh ((a\2) % 2));
     def a2 = bool (fresh ((a\4) % 2));

--- a/tests/tuples.pir
+++ b/tests/tuples.pir
@@ -7,14 +7,14 @@
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */
 // define higher order function
-def map f (a,b,c,d) {
+def map f (a,b,c,d) = {
     f a;
     f b;
     f c;
     f d
 };
 // defining a function
-def bool x { x*(x-1) = 0 };
+def bool x = { x*(x-1) = 0 };
 // user higher order function
 map bool q;
 // function value


### PR DESCRIPTION
Currently, definitions have two different syntaxes: `def <pat> = <expr>` and `def <id> <pat1> ... <patN> { <expr> }`. Both forms of definitions can be used to define functions. (The second form can be thought of as a value `<id>` parameterized by `<pat1>` through to `<patN>`.)

Whenever I'm parameterizing a function, for example changing `def myrange = range` to `def myrange a b { range a b }`, I frequently forget to insert braces and remove equals sign, so I end up with the following currently invalid code: `def myrange a b = range a b`.

In order to reduce the likelihood of users making this mistake and ease describing the syntax, this pull request changes the second syntax for definitions to be `def <id> <pat1> ... <patN> = <expr>`.