### PR TITLE
Upgrated PLONK backend and implemented public inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 [[package]]
 name = "plonk"
 version = "0.8.2"
-source = "git+https://github.com/ZK-Garage/plonk?rev=2c876bc9#2c876bc90d7833dc9cc5a36422e453fc03bd4b83"
+source = "git+https://github.com/ZK-Garage/plonk?rev=ec76fd3#ec76fd36cc6b9e9d0f7a9495094e76b86e53dab4"
 dependencies = [
  "plonk-core",
  "plonk-hashing",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "plonk-core"
 version = "0.1.0"
-source = "git+https://github.com/ZK-Garage/plonk?rev=2c876bc9#2c876bc90d7833dc9cc5a36422e453fc03bd4b83"
+source = "git+https://github.com/ZK-Garage/plonk?rev=ec76fd3#ec76fd36cc6b9e9d0f7a9495094e76b86e53dab4"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "plonk-hashing"
 version = "0.8.2"
-source = "git+https://github.com/ZK-Garage/plonk?rev=2c876bc9#2c876bc90d7833dc9cc5a36422e453fc03bd4b83"
+source = "git+https://github.com/ZK-Garage/plonk?rev=ec76fd3#ec76fd36cc6b9e9d0f7a9495094e76b86e53dab4"
 dependencies = [
  "plonk-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ clap = { version = "4.0.17", features = [ "derive" ] }
 num-bigint = "^0.4.0"
 bincode = "2.0.0-rc.1"
 rand_core = "0.6.3"
-plonk = { git = "https://github.com/ZK-Garage/plonk", rev = "2c876bc9" }
-plonk-core = { git = "https://github.com/ZK-Garage/plonk", rev = "2c876bc9", features = [ "std", "trace", "trace-print" ] }
+plonk = { git = "https://github.com/ZK-Garage/plonk", rev = "ec76fd3" }
+plonk-core = { git = "https://github.com/ZK-Garage/plonk", rev = "ec76fd3", features = [ "std", "trace", "trace-print" ] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use ark_poly_commit::{sonic_pc::SonicKZG10, PolynomialCommitment};
 use ark_poly::polynomial::univariate::DensePolynomial;
 use rand_core::OsRng;
 use plonk::error::to_pc_error;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use plonk_core::prelude::VerifierData;
 use crate::synth::PlonkModule;
@@ -165,11 +165,20 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
             input_variables.remove(&var.id);
         }
     }
-    
+    // Collect all public variables in order to enable annotations
+    let mut public_variables = HashSet::new();
+    for var in &annotated.pubs {
+        public_variables.insert(var.id);
+    }
     let mut var_assignments = HashMap::new();
     // Solicit input variables from user and solve for choice point values
     for (id, var) in input_variables {
-        print!("** {}: ", var);
+        let visibility = if public_variables.contains(&id) {
+            "(public)"
+        } else {
+            "(private)"
+        };
+        print!("** {} {}: ", var, visibility);
         std::io::stdout().flush().expect("flush failed!");
         let mut input_line = String::new();
         std::io::stdin()

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -5,9 +5,11 @@ use ark_ec::TEModelParameters;
 use plonk_core::circuit::Circuit;
 use plonk_core::constraint_system::StandardComposer;
 use plonk_core::error::Error;
+use plonk_core::proof_system::pi::PublicInputs;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use num_bigint::BigUint;
+use crate::ast::Variable;
 
 struct PrimeFieldBincode<T>(T) where T: PrimeField;
 
@@ -162,6 +164,28 @@ where
             *value = evaluate_expr(&var_expr, &mut definitions, &mut field_assigns);
         }
     }
+
+    /* Annotate the given public inputs with the variable names contained in
+     * this module. This function assumes that the public variables in this
+     * module and the public inputs in the argument occur in the same order. */
+    pub fn annotate_public_inputs(
+        &self,
+        intended_pi_pos: &Vec<usize>,
+        pi: &PublicInputs<F>
+    ) -> HashMap<VariableId, (Variable, F)> {
+        // First map public input positions to values
+        let mut pi_map = BTreeMap::new();
+        for (pos, val) in pi.get_pos().zip(pi.get_vals()) {
+            pi_map.insert(*pos, *val);
+        }
+        // Next, annotate the public inputs with this module's variables
+        let mut annotated = HashMap::new();
+        for (var, pos) in self.module.pubs.iter().zip(intended_pi_pos) {
+            let val = pi_map.get(&pos).copied().unwrap_or(F::zero());
+            annotated.insert(var.id, (var.clone(), val));
+        }
+        annotated
+    }
 }
 
 impl<F, P> Circuit<F, P> for PlonkModule<F, P>
@@ -180,6 +204,15 @@ where
             inputs.insert(var, composer.add_input(*field_elt));
         }
         let zero = composer.zero_var();
+        // It is assumed that the generated PublicInputs will share the same
+        // order as this module's public variables
+        for var in &self.module.pubs {
+            composer.arithmetic_gate(|gate| {
+                gate.witness(inputs[&var.id], zero, Some(zero))
+                    .add(-F::one(), F::zero())
+                    .pi(self.variable_map[&var.id])
+            });
+        }
         for expr in &self.module.exprs {
             if let Expr::Infix(InfixOp::Equal, lhs, rhs) = &expr.v {
                 match (&lhs.v, &rhs.v) {
@@ -782,6 +815,13 @@ where
     }
 
     fn padded_circuit_size(&self) -> usize {
-        self.module.exprs.len().next_power_of_two()
+        // The with_expected_size function adds the following gates:
+        // 1 gate to constrain the zero variable to equal 0
+        // 3 gates to add blinging factors to the circuit polynomials
+        const BUILTIN_GATE_COUNT: usize = 4;
+        (self.module.exprs.len() +
+         self.module.pubs.len() +
+         BUILTIN_GATE_COUNT
+        ).next_power_of_two()
     }
 }

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -4,7 +4,7 @@ COMMENT = _{ "//" ~ (!"\n" ~ ANY)* | "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
 lowercaseIdent = @{ (ASCII_ALPHA_LOWER | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
-keyword = { "fun" | "def" }
+keyword = { "fun" | "def" | "pub" }
 
 valueName = { !keyword ~ lowercaseIdent }
 
@@ -48,5 +48,6 @@ negate = { "-" }
 
 definition = { "def" ~ letBinding }
 
-moduleItems = _{ SOI ~ ( ( definition | expr ) ~ ";" )+ ~ EOI }
+declaration = { "pub" ~ valueName ~ ( ", " ~ valueName)* }
 
+moduleItems = _{ SOI ~ ( declaration ~ ";" )* ~ ( ( definition | expr ) ~ ";" )+ ~ EOI }

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -6,6 +6,8 @@
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */
 
+pub x;
+
 // Ensure that the given argument is 1 or 0, and returns it
 
 def bool x { x*(x-1) = 0; x };


### PR DESCRIPTION
Original plan was just to implement public inputs. In the course of doing this, realized that the latest PLONK backend API was required to achieve this. In particular, the `get_pos`, `get_vals`, and `intended_pi_pos` functions/values were utilized from the latest API. So also ended up upgrading the PLONK backend to the latest version.

Features implemented:
* A `pub <identifier1>, ..., <identifierN>` declaration statement was created to allow users to specify that the given identifiers are public inputs.
* Modified the verifier to print out all of the public inputs supplied annotated with variable names from the original source code.
* Added an example of the `pub` keyword being used. (See `range.pir`.)