### PR TITLE
Murisi/literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "ark-serialize",
  "bincode",
  "num-bigint",
+ "num-traits",
  "pest",
  "pest_derive",
  "plonk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ark-poly = "0.3"
 ark-poly-commit = "0.3"
 ark-serialize = "0.3.0"
 num-bigint = "^0.4.0"
+num-traits = "^0.2.14"
 bincode = "2.0.0-rc.1"
 rand_core = "0.6.3"
 plonk = { git = "https://github.com/ZK-Garage/plonk", rev = "2c876bc9" }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,6 +6,7 @@ use crate::pest::Parser;
 use bincode::{Encode, Decode};
 use std::collections::{HashMap, HashSet};
 use crate::transform::VarGen;
+use num_bigint::BigInt;
 #[derive(Parser)]
 #[grammar = "vampir.pest"]
 pub struct VampirParser;
@@ -156,13 +157,34 @@ impl fmt::Display for LetBinding {
     }
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
+// This structure is required to Bincode BigInts
+struct BigIntBincode(BigInt);
+
+impl bincode::Encode for BigIntBincode {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> core::result::Result<(), bincode::error::EncodeError> {
+        self.0.to_signed_bytes_le().encode(encoder)
+    }
+}
+
+impl bincode::Decode for BigIntBincode {
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> core::result::Result<Self, bincode::error::DecodeError> {
+        let digits = Vec::<u8>::decode(decoder)?;
+        Ok(Self(BigInt::from_signed_bytes_le(&digits)))
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum Pattern {
     Unit,
     As(Box<Pattern>, Variable),
     Product(Box<Pattern>, Box<Pattern>),
     Variable(Variable),
-    Constant(i32),
+    Constant(BigInt),
 }
 
 impl Pattern {
@@ -217,7 +239,7 @@ impl Pattern {
     pub fn to_expr(&self) -> TExpr {
         match self {
             Self::Unit => Expr::Unit.into(),
-            Self::Constant(val) => Expr::Constant(*val).into(),
+            Self::Constant(val) => Expr::Constant(val.clone()).into(),
             Self::Variable(var) => Expr::Variable(var.clone()).into(),
             Self::As(pat, _name) => pat.to_expr(),
             Self::Product(pat1, pat2) => {
@@ -234,7 +256,7 @@ impl Pattern {
             (Self::Unit, Type::Unit | Type::Variable(_)) =>
                 TExpr { v: Expr::Unit, t: Some(Type::Unit) },
             (Self::Constant(val), Type::Int | Type::Variable(_)) =>
-                TExpr { v: Expr::Constant(*val), t: Some(Type::Int) },
+                TExpr { v: Expr::Constant(val.clone()), t: Some(Type::Int) },
             (Self::Variable(var), typ) =>
                 TExpr { v:Expr::Variable(var.clone()), t: Some(typ) },
             (Self::As(pat, _name), typ) => pat.to_typed_expr(typ),
@@ -266,13 +288,85 @@ impl fmt::Display for Pattern {
     }
 }
 
+// Encode is manually implemented for Pattern because some of its fields do not
+// implement Encode. This implementation uses wrappers to effect the encoding of
+// problematic fields.
+impl :: bincode :: Encode for Pattern
+{
+    fn encode < E : :: bincode :: enc :: Encoder > (& self, encoder : & mut E)
+    -> core :: result :: Result < (), :: bincode :: error :: EncodeError >
+    {
+        match self
+        {
+            Self :: Unit =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (0u32), encoder) ?
+                ; Ok(())
+            }, Self :: As(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (1u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Product(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (2u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Variable(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (3u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Constant(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (4u32), encoder) ?
+                ; :: bincode :: Encode :: encode(&BigIntBincode(field_0.clone()), encoder) ? ; Ok(())
+            },
+        }
+    }
+}
+
+// Decode is manually implemented for Pattern because some of its fields do not
+// implement Decode. This implementation uses wrappers to effect the decoding of
+// problematic fields.
+impl :: bincode :: Decode for Pattern
+{
+    fn decode < D : :: bincode :: de :: Decoder > (decoder : & mut D) -> core
+    :: result :: Result < Self, :: bincode :: error :: DecodeError >
+    {
+        let variant_index = < u32 as :: bincode :: Decode > :: decode(decoder)
+        ? ; match variant_index
+        {
+            0u32 => Ok(Self :: Unit {}), 1u32 =>
+            Ok(Self :: As
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 2u32 =>
+            Ok(Self :: Product
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 3u32 =>
+            Ok(Self :: Variable
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 4u32 =>
+            Ok(Self :: Constant
+            { 0 : <BigIntBincode as :: bincode :: Decode> :: decode(decoder) ?.0, }), variant =>
+            Err(:: bincode :: error :: DecodeError :: UnexpectedVariant
+            {
+                found : variant, type_name : "Pattern", allowed : :: bincode
+                :: error :: AllowedEnumVariants :: Range { min : 0, max : 4 }
+            })
+        }
+    }
+}
+
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct TExpr {
     pub v: Expr,
     pub t: Option<Type>,
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Clone)]
 pub enum Expr {
     Unit,
     Sequence(Vec<TExpr>),
@@ -280,12 +374,137 @@ pub enum Expr {
     Infix(InfixOp, Box<TExpr>, Box<TExpr>),
     Negate(Box<TExpr>),
     Application(Box<TExpr>, Box<TExpr>),
-    Constant(i32),
+    Constant(BigInt),
     Variable(Variable),
     Function(Function),
     Intrinsic(Intrinsic),
     LetBinding(LetBinding, Box<TExpr>),
     Match(Match),
+}
+
+// Encode is manually implemented for Expr because some of its fields do not
+// implement Encode. This implementation uses wrappers to effect the encoding of
+// problematic fields.
+impl :: bincode :: Encode for Expr
+{
+    fn encode < E : :: bincode :: enc :: Encoder > (& self, encoder : & mut E)
+    -> core :: result :: Result < (), :: bincode :: error :: EncodeError >
+    {
+        match self
+        {
+            Self :: Unit =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (0u32), encoder) ?
+                ; Ok(())
+            }, Self :: Sequence(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (1u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Product(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (2u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Infix(field_0, field_1, field_2) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (3u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; :: bincode
+                :: Encode :: encode(field_2, encoder) ? ; Ok(())
+            }, Self :: Negate(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (4u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Application(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (5u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Constant(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (6u32), encoder) ?
+                ; :: bincode :: Encode :: encode(&BigIntBincode(field_0.clone()), encoder) ? ; Ok(())
+            }, Self :: Variable(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (7u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Function(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (8u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Intrinsic(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (9u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: LetBinding(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (10u32), encoder)
+                ? ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Match(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (11u32), encoder)
+                ? ; :: bincode :: Encode :: encode(field_0, encoder) ? ;
+                Ok(())
+            },
+        }
+    }
+}
+
+// Decode is manually implemented for Expr because some of its fields do not
+// implement Decode. This implementation uses wrappers to effect the decoding of
+// problematic fields.
+impl :: bincode :: Decode for Expr
+{
+    fn decode < D : :: bincode :: de :: Decoder > (decoder : & mut D) -> core
+    :: result :: Result < Self, :: bincode :: error :: DecodeError >
+    {
+        let variant_index = < u32 as :: bincode :: Decode > :: decode(decoder)
+        ? ; match variant_index
+        {
+            0u32 => Ok(Self :: Unit {}), 1u32 =>
+            Ok(Self :: Sequence
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 2u32 =>
+            Ok(Self :: Product
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 3u32 =>
+            Ok(Self :: Infix
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?, 2 : :: bincode :: Decode ::
+                decode(decoder) ?,
+            }), 4u32 =>
+            Ok(Self :: Negate
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 5u32 =>
+            Ok(Self :: Application
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 6u32 =>
+            Ok(Self :: Constant
+            { 0 : <BigIntBincode as :: bincode :: Decode> :: decode(decoder) ?.0, }), 7u32 =>
+            Ok(Self :: Variable
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 8u32 =>
+            Ok(Self :: Function
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 9u32 =>
+            Ok(Self :: Intrinsic
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 10u32 =>
+            Ok(Self :: LetBinding
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 11u32 =>
+            Ok(Self :: Match
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), variant =>
+            Err(:: bincode :: error :: DecodeError :: UnexpectedVariant
+            {
+                found : variant, type_name : "Expr", allowed : :: bincode ::
+                error :: AllowedEnumVariants :: Range { min : 0, max : 11 }
+            })
+        }
+    }
 }
 
 impl TExpr {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use plonk::error::to_pc_error;
 use std::collections::HashMap;
 use std::io::Write;
 use plonk_core::prelude::VerifierData;
-use crate::synth::PlonkModule;
+use crate::synth::{PlonkModule, make_constant};
 use plonk_core::circuit::Circuit;
 use ark_ff::PrimeField;
 use std::fs::File;
@@ -28,6 +28,7 @@ use plonk_core::proof_system::{ProverKey, VerifierKey, Proof};
 use plonk_core::proof_system::pi::PublicInputs;
 use bincode::error::{DecodeError, EncodeError};
 use ark_serialize::{Read, SerializationError};
+use num_bigint::BigInt;
 
 type PC = SonicKZG10<Bls12_381, DensePolynomial<BlsScalar>>;
 
@@ -92,12 +93,12 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
         std::io::stdin()
             .read_line(&mut input_line)
             .expect("failed to read input");
-        let x: F = if let Ok(x) = input_line.trim().parse() {
+        let x: BigInt = if let Ok(x) = input_line.trim().parse() {
             x
         } else {
             panic!("input not an integer");
         };
-        var_assignments.insert(id, x);
+        var_assignments.insert(id, make_constant(&x));
     }
     var_assignments
 }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -36,7 +36,7 @@ impl<T> bincode::Decode for PrimeFieldBincode<T> where T: PrimeField {
 }
 
 // Make field elements from signed values
-fn make_constant<F: PrimeField>(c: &BigInt) -> F {
+pub fn make_constant<F: PrimeField>(c: &BigInt) -> F {
     let magnitude = F::from(c.magnitude().clone());
     if c.is_positive() {
         magnitude

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -10,7 +10,7 @@ valueName = { !keyword ~ lowercaseIdent }
 
 infixOp = { "/" | "*" | "+" | "-" | "=" | "^" }
 
-integerLiteral = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+integerLiteral = @{ "-"? ~ ( "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* ) }
 
 constant = { integerLiteral | "(" ~ ")" }
 

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,0 +1,18 @@
+/* An script to test out large integer arithmetic. x must be
+   342342428479792353453543986. Run
+   as follows:
+   vamp-ir setup params.pp
+   vamp-ir compile tests/ints.pir params.pp circuit.plonk
+   vamp-ir prove circuit.plonk params.pp proof.plonk
+   vamp-ir verify circuit.plonk params.pp proof.plonk
+*/
+
+// Make a large number
+def a = 342342428479792353453543987;
+
+// Check if computations with it are correct;
+a*a = 117198338337441742664441569861251354629164970143856169;
+a+1 = 342342428479792353453543988;
+
+// Check if large int prompts work
+a = x+1;

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,5 +1,5 @@
 /* An script to test out large integer arithmetic. x must be
-   342342428479792353453543986. Run
+   342342428479792353453543986 and c must be -32. Run
    as follows:
    vamp-ir setup params.pp
    vamp-ir compile tests/ints.pir params.pp circuit.plonk
@@ -16,3 +16,7 @@ a+1 = 342342428479792353453543988;
 
 // Check if large int prompts work
 a = x+1;
+
+// Check negative number functioning
+def b = -8;
+b*4 = c;


### PR DESCRIPTION
Made the changes regarding valid int literals in vampir. The changes are as follows:
* Negative integer literals in the prover prompt can now be parsed
* Added support for large integers in vampir source files
* Added some test to exercise this large integer facility

Bincode serialization code was added in order to support serialization of ASTs containing `BigInts`.