### PR TITLE
Murisi/literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "bincode",
  "clap",
  "num-bigint",
+ "num-traits",
  "pest",
  "pest_derive",
  "plonk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ark-poly-commit = "0.3"
 ark-serialize = "0.3.0"
 clap = { version = "4.0.17", features = [ "derive" ] }
 num-bigint = "^0.4.0"
+num-traits = "^0.2.14"
 bincode = "2.0.0-rc.1"
 rand_core = "0.6.3"
 plonk = { git = "https://github.com/ZK-Garage/plonk", rev = "2c876bc9" }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,6 +7,8 @@ use bincode::{Encode, Decode};
 use std::collections::{HashMap, HashSet};
 use crate::transform::VarGen;
 use num_bigint::BigInt;
+use num_traits::Num;
+use std::ops::Neg;
 #[derive(Parser)]
 #[grammar = "vampir.pest"]
 pub struct VampirParser;
@@ -507,6 +509,33 @@ impl :: bincode :: Decode for Expr
     }
 }
 
+/* Parse signed integer literals beginning with at most one occurrence of 0x
+ * (indicating a radix of 16), 0o (radix 8), or 0b (radix 2). */
+pub fn parse_prefixed_num<T>(string: &str) -> Result<T, T::FromStrRadixErr>
+where T: Num + Neg<Output = T> {
+    // Process the number's sign
+    let (pos, magnitude) =
+        if let Some(rest) = string.strip_prefix("-") {
+            (false, rest)
+        } else if let Some(rest) = string.strip_prefix("+") {
+            (true, rest)
+        } else {
+            (true, string)
+        };
+    // Process the number's radix
+    let magnitude = if let Some(rest) = magnitude.strip_prefix("0b") {
+        T::from_str_radix(rest, 2)
+    } else if let Some(rest) = magnitude.strip_prefix("0o") {
+        T::from_str_radix(rest, 8)
+    } else if let Some(rest) = magnitude.strip_prefix("0x") {
+        T::from_str_radix(rest, 16)
+    } else {
+        T::from_str_radix(magnitude, 10)
+    }?;
+    // Combine magnitude and sign
+    Ok(if pos { magnitude } else { -magnitude })
+}
+
 impl TExpr {
     pub fn parse(pair: Pair<Rule>) -> Option<Self> {
         if pair.as_rule() != Rule::expr { return None }
@@ -661,7 +690,8 @@ impl TExpr {
         if pair.as_rule() == Rule::constant && string.starts_with("(") {
             Some(Expr::Unit.into())
         } else if pair.as_rule() == Rule::constant {
-            let value = pair.as_str().parse().ok().expect("constant should be an integer");
+            let value = parse_prefixed_num(pair.as_str())
+                .expect("constant should be an integer");
             Some(Expr::Constant(value).into())
         } else if pair.as_rule() == Rule::valueName {
             let name = Variable::parse(pair).expect("expression should be value name");

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,6 +6,7 @@ use crate::pest::Parser;
 use bincode::{Encode, Decode};
 use std::collections::{HashMap, HashSet};
 use crate::transform::VarGen;
+use num_bigint::BigInt;
 #[derive(Parser)]
 #[grammar = "vampir.pest"]
 pub struct VampirParser;
@@ -156,13 +157,34 @@ impl fmt::Display for LetBinding {
     }
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
+// This structure is required to Bincode BigInts
+struct BigIntBincode(BigInt);
+
+impl bincode::Encode for BigIntBincode {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> core::result::Result<(), bincode::error::EncodeError> {
+        self.0.to_signed_bytes_le().encode(encoder)
+    }
+}
+
+impl bincode::Decode for BigIntBincode {
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> core::result::Result<Self, bincode::error::DecodeError> {
+        let digits = Vec::<u8>::decode(decoder)?;
+        Ok(Self(BigInt::from_signed_bytes_le(&digits)))
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum Pattern {
     Unit,
     As(Box<Pattern>, Variable),
     Product(Box<Pattern>, Box<Pattern>),
     Variable(Variable),
-    Constant(i32),
+    Constant(BigInt),
 }
 
 impl Pattern {
@@ -217,7 +239,7 @@ impl Pattern {
     pub fn to_expr(&self) -> TExpr {
         match self {
             Self::Unit => Expr::Unit.into(),
-            Self::Constant(val) => Expr::Constant(*val).into(),
+            Self::Constant(val) => Expr::Constant(val.clone()).into(),
             Self::Variable(var) => Expr::Variable(var.clone()).into(),
             Self::As(pat, _name) => pat.to_expr(),
             Self::Product(pat1, pat2) => {
@@ -234,7 +256,7 @@ impl Pattern {
             (Self::Unit, Type::Unit | Type::Variable(_)) =>
                 TExpr { v: Expr::Unit, t: Some(Type::Unit) },
             (Self::Constant(val), Type::Int | Type::Variable(_)) =>
-                TExpr { v: Expr::Constant(*val), t: Some(Type::Int) },
+                TExpr { v: Expr::Constant(val.clone()), t: Some(Type::Int) },
             (Self::Variable(var), typ) =>
                 TExpr { v:Expr::Variable(var.clone()), t: Some(typ) },
             (Self::As(pat, _name), typ) => pat.to_typed_expr(typ),
@@ -266,13 +288,85 @@ impl fmt::Display for Pattern {
     }
 }
 
+// Encode is manually implemented for Pattern because some of its fields do not
+// implement Encode. This implementation uses wrappers to effect the encoding of
+// problematic fields.
+impl :: bincode :: Encode for Pattern
+{
+    fn encode < E : :: bincode :: enc :: Encoder > (& self, encoder : & mut E)
+    -> core :: result :: Result < (), :: bincode :: error :: EncodeError >
+    {
+        match self
+        {
+            Self :: Unit =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (0u32), encoder) ?
+                ; Ok(())
+            }, Self :: As(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (1u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Product(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (2u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Variable(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (3u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Constant(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (4u32), encoder) ?
+                ; :: bincode :: Encode :: encode(&BigIntBincode(field_0.clone()), encoder) ? ; Ok(())
+            },
+        }
+    }
+}
+
+// Decode is manually implemented for Pattern because some of its fields do not
+// implement Decode. This implementation uses wrappers to effect the decoding of
+// problematic fields.
+impl :: bincode :: Decode for Pattern
+{
+    fn decode < D : :: bincode :: de :: Decoder > (decoder : & mut D) -> core
+    :: result :: Result < Self, :: bincode :: error :: DecodeError >
+    {
+        let variant_index = < u32 as :: bincode :: Decode > :: decode(decoder)
+        ? ; match variant_index
+        {
+            0u32 => Ok(Self :: Unit {}), 1u32 =>
+            Ok(Self :: As
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 2u32 =>
+            Ok(Self :: Product
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 3u32 =>
+            Ok(Self :: Variable
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 4u32 =>
+            Ok(Self :: Constant
+            { 0 : <BigIntBincode as :: bincode :: Decode> :: decode(decoder) ?.0, }), variant =>
+            Err(:: bincode :: error :: DecodeError :: UnexpectedVariant
+            {
+                found : variant, type_name : "Pattern", allowed : :: bincode
+                :: error :: AllowedEnumVariants :: Range { min : 0, max : 4 }
+            })
+        }
+    }
+}
+
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct TExpr {
     pub v: Expr,
     pub t: Option<Type>,
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Clone)]
 pub enum Expr {
     Unit,
     Sequence(Vec<TExpr>),
@@ -280,12 +374,137 @@ pub enum Expr {
     Infix(InfixOp, Box<TExpr>, Box<TExpr>),
     Negate(Box<TExpr>),
     Application(Box<TExpr>, Box<TExpr>),
-    Constant(i32),
+    Constant(BigInt),
     Variable(Variable),
     Function(Function),
     Intrinsic(Intrinsic),
     LetBinding(LetBinding, Box<TExpr>),
     Match(Match),
+}
+
+// Encode is manually implemented for Expr because some of its fields do not
+// implement Encode. This implementation uses wrappers to effect the encoding of
+// problematic fields.
+impl :: bincode :: Encode for Expr
+{
+    fn encode < E : :: bincode :: enc :: Encoder > (& self, encoder : & mut E)
+    -> core :: result :: Result < (), :: bincode :: error :: EncodeError >
+    {
+        match self
+        {
+            Self :: Unit =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (0u32), encoder) ?
+                ; Ok(())
+            }, Self :: Sequence(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (1u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Product(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (2u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Infix(field_0, field_1, field_2) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (3u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; :: bincode
+                :: Encode :: encode(field_2, encoder) ? ; Ok(())
+            }, Self :: Negate(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (4u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Application(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (5u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Constant(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (6u32), encoder) ?
+                ; :: bincode :: Encode :: encode(&BigIntBincode(field_0.clone()), encoder) ? ; Ok(())
+            }, Self :: Variable(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (7u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Function(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (8u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: Intrinsic(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (9u32), encoder) ?
+                ; :: bincode :: Encode :: encode(field_0, encoder) ? ; Ok(())
+            }, Self :: LetBinding(field_0, field_1) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (10u32), encoder)
+                ? ; :: bincode :: Encode :: encode(field_0, encoder) ? ; ::
+                bincode :: Encode :: encode(field_1, encoder) ? ; Ok(())
+            }, Self :: Match(field_0) =>
+            {
+                < u32 as :: bincode :: Encode > :: encode(& (11u32), encoder)
+                ? ; :: bincode :: Encode :: encode(field_0, encoder) ? ;
+                Ok(())
+            },
+        }
+    }
+}
+
+// Decode is manually implemented for Expr because some of its fields do not
+// implement Decode. This implementation uses wrappers to effect the decoding of
+// problematic fields.
+impl :: bincode :: Decode for Expr
+{
+    fn decode < D : :: bincode :: de :: Decoder > (decoder : & mut D) -> core
+    :: result :: Result < Self, :: bincode :: error :: DecodeError >
+    {
+        let variant_index = < u32 as :: bincode :: Decode > :: decode(decoder)
+        ? ; match variant_index
+        {
+            0u32 => Ok(Self :: Unit {}), 1u32 =>
+            Ok(Self :: Sequence
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 2u32 =>
+            Ok(Self :: Product
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 3u32 =>
+            Ok(Self :: Infix
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?, 2 : :: bincode :: Decode ::
+                decode(decoder) ?,
+            }), 4u32 =>
+            Ok(Self :: Negate
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 5u32 =>
+            Ok(Self :: Application
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 6u32 =>
+            Ok(Self :: Constant
+            { 0 : <BigIntBincode as :: bincode :: Decode> :: decode(decoder) ?.0, }), 7u32 =>
+            Ok(Self :: Variable
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 8u32 =>
+            Ok(Self :: Function
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 9u32 =>
+            Ok(Self :: Intrinsic
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), 10u32 =>
+            Ok(Self :: LetBinding
+            {
+                0 : :: bincode :: Decode :: decode(decoder) ?, 1 : :: bincode
+                :: Decode :: decode(decoder) ?,
+            }), 11u32 =>
+            Ok(Self :: Match
+            { 0 : :: bincode :: Decode :: decode(decoder) ?, }), variant =>
+            Err(:: bincode :: error :: DecodeError :: UnexpectedVariant
+            {
+                found : variant, type_name : "Expr", allowed : :: bincode ::
+                error :: AllowedEnumVariants :: Range { min : 0, max : 11 }
+            })
+        }
+    }
 }
 
 impl TExpr {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 use std::fs;
-use crate::ast::{Module, VariableId, Pattern};
+use crate::ast::{Module, VariableId, Pattern, parse_prefixed_num};
 use crate::transform::{compile, collect_module_variables};
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ed_on_bls12_381::EdwardsParameters as JubJubParameters;
@@ -30,7 +30,6 @@ use bincode::error::{DecodeError, EncodeError};
 use ark_serialize::{Read, SerializationError};
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
-use num_bigint::BigInt;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -176,11 +175,8 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
         std::io::stdin()
             .read_line(&mut input_line)
             .expect("failed to read input");
-        let x: BigInt = if let Ok(x) = input_line.trim().parse() {
-            x
-        } else {
-            panic!("input not an integer");
-        };
+        let x = parse_prefixed_num(input_line.trim())
+            .expect("input not an integer");
         var_assignments.insert(id, make_constant(&x));
     }
     var_assignments

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use plonk::error::to_pc_error;
 use std::collections::HashMap;
 use std::io::Write;
 use plonk_core::prelude::VerifierData;
-use crate::synth::PlonkModule;
+use crate::synth::{PlonkModule, make_constant};
 use plonk_core::circuit::Circuit;
 use ark_ff::PrimeField;
 use std::fs::File;
@@ -30,6 +30,7 @@ use bincode::error::{DecodeError, EncodeError};
 use ark_serialize::{Read, SerializationError};
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+use num_bigint::BigInt;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -175,12 +176,12 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
         std::io::stdin()
             .read_line(&mut input_line)
             .expect("failed to read input");
-        let x: F = if let Ok(x) = input_line.trim().parse() {
+        let x: BigInt = if let Ok(x) = input_line.trim().parse() {
             x
         } else {
             panic!("input not an integer");
         };
-        var_assignments.insert(id, x);
+        var_assignments.insert(id, make_constant(&x));
     }
     var_assignments
 }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -36,7 +36,7 @@ impl<T> bincode::Decode for PrimeFieldBincode<T> where T: PrimeField {
 }
 
 // Make field elements from signed values
-fn make_constant<F: PrimeField>(c: &BigInt) -> F {
+pub fn make_constant<F: PrimeField>(c: &BigInt) -> F {
     let magnitude = F::from(c.magnitude().clone());
     if c.is_positive() {
         magnitude

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -7,7 +7,8 @@ use plonk_core::constraint_system::StandardComposer;
 use plonk_core::error::Error;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
-use num_bigint::BigUint;
+use num_bigint::{BigUint, BigInt};
+use num_traits::Signed;
 
 struct PrimeFieldBincode<T>(T) where T: PrimeField;
 
@@ -35,11 +36,12 @@ impl<T> bincode::Decode for PrimeFieldBincode<T> where T: PrimeField {
 }
 
 // Make field elements from signed values
-fn make_constant<F: PrimeField>(c: i32) -> F {
-    if c >= 0 {
-        F::from(c as u32)
+fn make_constant<F: PrimeField>(c: &BigInt) -> F {
+    let magnitude = F::from(c.magnitude().clone());
+    if c.is_positive() {
+        magnitude
     } else {
-        -F::from((-c) as u32)
+        -magnitude
     }
 }
 
@@ -50,7 +52,7 @@ fn evaluate_expr<F>(
     assigns: &mut HashMap<VariableId, F>,
 ) -> F where F: PrimeField {
     match &expr.v {
-        Expr::Constant(c) => make_constant(*c),
+        Expr::Constant(c) => make_constant(c),
         Expr::Variable(v) => {
             if let Some(val) = assigns.get(&v.id) {
                 // First look for existing variable assignment
@@ -202,7 +204,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c2))
+                                .constant(make_constant(&-c2))
                         });
                     },
                     // v1 = -c2
@@ -213,7 +215,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(*c2))
+                                .constant(make_constant(c2))
                         });
                         true
                     }) => {},
@@ -239,7 +241,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c2-c3))
+                                .constant(make_constant(&(-c2-c3)))
                         });
                         true
                     }) => {},
@@ -254,7 +256,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(-c3))
+                                .constant(make_constant(&-c3))
                         });
                         true
                     }) => {},
@@ -269,7 +271,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(-c2))
+                                .constant(make_constant(&-c2))
                         });
                         true
                     }) => {},
@@ -299,7 +301,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c2+c3))
+                                .constant(make_constant(&(-c2+c3)))
                         });
                         true
                     }) => {},
@@ -314,7 +316,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(*c3))
+                                .constant(make_constant(c3))
                         });
                         true
                     }) => {},
@@ -329,7 +331,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), F::one())
-                                .constant(make_constant(-c2))
+                                .constant(make_constant(&-c2))
                         });
                         true
                     }) => {},
@@ -356,8 +358,8 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c2);
-                        let op2: F = make_constant(*c3);
+                        let op1: F = make_constant(c2);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
@@ -373,7 +375,7 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op2: F = make_constant(*c3);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -(F::one()/op2))
@@ -388,7 +390,7 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c2);
+                        let op1: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .mul(F::one())
@@ -419,8 +421,8 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c2);
-                        let op2: F = make_constant(*c3);
+                        let op1: F = make_constant(c2);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
@@ -436,7 +438,7 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op2: F = make_constant(*c3);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -op2)
@@ -451,7 +453,7 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op2: F = make_constant(*c2);
+                        let op2: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -op2)
@@ -482,7 +484,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c1))
+                                .constant(make_constant(&-c1))
                         });
                     },
                     // c1 = c2
@@ -493,7 +495,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c2-c1))
+                                .constant(make_constant(&(c2-c1)))
                         });
                     },
                     // c1 = -c2
@@ -504,7 +506,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c1+*c2))
+                                .constant(make_constant(&(c1+c2)))
                         });
                         true
                     }) => {},
@@ -516,7 +518,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(*c1))
+                                .constant(make_constant(c1))
                         });
                         true
                     }) => {},
@@ -531,7 +533,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c1-c2-c3))
+                                .constant(make_constant(&(c1-c2-c3)))
                         });
                         true
                     }) => {},
@@ -546,7 +548,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(c3-c1))
+                                .constant(make_constant(&(c3-c1)))
                         });
                         true
                     }) => {},
@@ -561,7 +563,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(c2-c1))
+                                .constant(make_constant(&(c2-c1)))
                         });
                         true
                     }) => {},
@@ -576,7 +578,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), F::one())
-                                .constant(make_constant(-c1))
+                                .constant(make_constant(&-c1))
                         });
                         true
                     }) => {},
@@ -591,7 +593,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c2-c3-c1))
+                                .constant(make_constant(&(c2-c3-c1)))
                         });
                         true
                     }) => {},
@@ -606,7 +608,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-*c3-c1))
+                                .constant(make_constant(&(-c3-c1)))
                         });
                         true
                     }) => {},
@@ -621,7 +623,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(c1-c2))
+                                .constant(make_constant(&(c1-c2)))
                         });
                         true
                     }) => {},
@@ -636,7 +638,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(-c1))
+                                .constant(make_constant(&-c1))
                         });
                         true
                     }) => {},
@@ -648,9 +650,9 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
@@ -666,8 +668,8 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
@@ -683,8 +685,8 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .constant(-(op2/op1))
@@ -699,7 +701,7 @@ where
                         Expr::Variable(v2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
+                        let op1: F = make_constant(c1);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -op1)
@@ -714,9 +716,9 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
@@ -732,8 +734,8 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(op3, F::zero())
@@ -749,8 +751,8 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .add(op2, F::zero())
@@ -766,7 +768,7 @@ where
                         Expr::Variable(v2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
+                        let op1: F = make_constant(c1);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .mul(F::one())
@@ -782,6 +784,10 @@ where
     }
 
     fn padded_circuit_size(&self) -> usize {
-        self.module.exprs.len().next_power_of_two()
+        // The with_expected_size function adds the following gates:
+        // 1 gate to constrain the zero variable to equal 0
+        // 3 gates to add blinging factors to the circuit polynomials
+        const BUILTIN_GATE_COUNT: usize = 4;
+        (self.module.exprs.len()+BUILTIN_GATE_COUNT).next_power_of_two()
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use crate::typecheck::{infer_module_types, expand_module_variables, unitize_module_functions, print_types, Type};
 use crate::ast::{Module, Definition, TExpr, Pattern, VariableId, LetBinding, Variable, InfixOp, Expr, Intrinsic, Function, Match};
+use ark_ff::{One, Zero};
+use num_traits::sign::Signed;
 
 /* A structure for generating unique variable IDs. */
 pub struct VarGen(VariableId);
@@ -534,17 +536,17 @@ pub fn collect_module_variables(
  * simplifications. */
 fn infix_op(op: InfixOp, e1: TExpr, e2: TExpr) -> TExpr {
     match (op, &e1.v, &e2.v) {
-        (InfixOp::Multiply, Expr::Constant(1), _) => e2,
-        (InfixOp::Multiply, _, Expr::Constant(1)) => e1,
-        (InfixOp::Multiply, Expr::Constant(0), _) => e1,
-        (InfixOp::Multiply, _, Expr::Constant(0)) => e2,
-        (InfixOp::Divide, _, Expr::Constant(1)) => e1,
-        (InfixOp::IntDivide, _, Expr::Constant(1)) => e1,
-        (InfixOp::Modulo, _, Expr::Constant(1)) =>
-            TExpr { v: Expr::Constant(0), t: Some(Type::Int) },
-        (InfixOp::Add, Expr::Constant(0), _) => e2,
-        (InfixOp::Add, _, Expr::Constant(0)) => e1,
-        (InfixOp::Subtract, _, Expr::Constant(0)) => e1,
+        (InfixOp::Multiply, Expr::Constant(c), _) if c.is_one() => e2,
+        (InfixOp::Multiply, _, Expr::Constant(c)) if c.is_one() => e1,
+        (InfixOp::Multiply, Expr::Constant(c), _) if c.is_zero() => e1,
+        (InfixOp::Multiply, _, Expr::Constant(c)) if c.is_zero() => e2,
+        (InfixOp::Divide, _, Expr::Constant(c)) if c.is_one() => e1,
+        (InfixOp::IntDivide, _, Expr::Constant(c)) if c.is_one() => e1,
+        (InfixOp::Modulo, _, Expr::Constant(c)) if c.is_one() =>
+            TExpr { v: Expr::Constant(Zero::zero()), t: Some(Type::Int) },
+        (InfixOp::Add, Expr::Constant(c), _) if c.is_zero() => e2,
+        (InfixOp::Add, _, Expr::Constant(c)) if c.is_zero() => e1,
+        (InfixOp::Subtract, _, Expr::Constant(c)) if c.is_zero() => e1,
         (InfixOp::Equal, _, _) =>
             TExpr {
                 v: Expr::Infix(op, Box::new(e1), Box::new(e2)),
@@ -580,7 +582,7 @@ fn flatten_binding(
                  Expr::Infix(_, _, _) | Expr::Negate(_)) => {
             flattened.exprs.push(Expr::Infix(
                 InfixOp::Equal,
-                Box::new(Expr::Constant(*pat).into()),
+                Box::new(Expr::Constant(pat.clone()).into()),
                 Box::new(expr.clone()),
             ).into());
         },
@@ -710,7 +712,7 @@ fn flatten_expr_to_3ac(
     gen: &mut VarGen,
 ) -> Pattern {
     match (out, &expr.v) {
-        (None, Expr::Constant(val)) => Pattern::Constant(*val),
+        (None, Expr::Constant(val)) => Pattern::Constant(val.clone()),
         (None, Expr::Variable(var)) => Pattern::Variable(var.clone()),
         (Some(pat),
          Expr::Constant(_) | Expr::Variable(_)) => {
@@ -726,12 +728,12 @@ fn flatten_expr_to_3ac(
             out
         },
         (out, Expr::Infix(InfixOp::Exponentiate, e1, e2)) => {
-            match e2.v {
-                Expr::Constant(0) =>
-                    flatten_expr_to_3ac(out, &Expr::Constant(1).into(), flattened, gen),
-                Expr::Constant(1) =>
+            match &e2.v {
+                Expr::Constant(c) if c.is_zero() =>
+                    flatten_expr_to_3ac(out, &Expr::Constant(One::one()).into(), flattened, gen),
+                Expr::Constant(c) if c.is_one() =>
                     flatten_expr_to_3ac(out, e1, flattened, gen),
-                Expr::Constant(v2) if v2 > 0 => {
+                Expr::Constant(v2) if v2.is_positive() => {
                     // Compute the base once and for all
                     let out1_term = flatten_expr_to_3ac(None, e1, flattened, gen);
                     // Compute roughly the sqrt of this expression
@@ -749,7 +751,7 @@ fn flatten_expr_to_3ac(
                     );
                     // Multiply by the base once more in order to obtain
                     // original value
-                    if v2%2 == 1 {
+                    if v2%2 == One::one() {
                         rhs = infix_op(
                             InfixOp::Multiply,
                             rhs,
@@ -769,7 +771,7 @@ fn flatten_expr_to_3ac(
                     // Now invert the value to obtain this expression
                     let rhs = infix_op(
                         InfixOp::Divide,
-                        Expr::Constant(1).into(),
+                        Expr::Constant(One::one()).into(),
                         out1_term.to_expr()
                     );
                     flatten_expr_to_3ac(out, &rhs, flattened, gen)
@@ -837,7 +839,7 @@ pub fn flatten_module_to_3ac(
                 (_, Expr::Constant(val), ohs, _) |
                 (ohs, _, _, Expr::Constant(val)) => {
                     flatten_expr_to_3ac(
-                        Some(Pattern::Constant(*val)),
+                        Some(Pattern::Constant(val.clone())),
                         ohs,
                         flattened,
                         gen

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -10,7 +10,13 @@ valueName = { !keyword ~ lowercaseIdent }
 
 infixOp = { "/" | "*" | "+" | "-" | "=" | "^" | "\\" | "%" }
 
-integerLiteral = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+binary = @{ '0'..'1' }
+
+octal = @{ '0'..'7' }
+
+hexadecimal = @{ '0'..'9' | 'a'..'f' | 'A'..'F' }
+
+integerLiteral = @{ "0x" ~ hexadecimal+ | "0o" ~ octal+ | "0b" ~ binary+ | ASCII_DIGIT+ }
 
 constant = { integerLiteral | "(" ~ ")" }
 

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,0 +1,18 @@
+/* An script to test out large integer arithmetic. x must be
+   342342428479792353453543986. Run
+   as follows:
+   vamp-ir setup params.pp
+   vamp-ir compile tests/ints.pir params.pp circuit.plonk
+   vamp-ir prove circuit.plonk params.pp proof.plonk
+   vamp-ir verify circuit.plonk params.pp proof.plonk
+*/
+
+// Make a large number
+def a = 342342428479792353453543987;
+
+// Check if computations with it are correct;
+a*a = 117198338337441742664441569861251354629164970143856169;
+a+1 = 342342428479792353453543988;
+
+// Check if large int prompts work
+a = x+1;

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,5 +1,5 @@
 /* An script to test out large integer arithmetic. x must be
-   342342428479792353453543986. Run
+   342342428479792353453543986 and c must be -32. Run
    as follows:
    vamp-ir setup params.pp
    vamp-ir compile tests/ints.pir params.pp circuit.plonk
@@ -16,3 +16,7 @@ a+1 = 342342428479792353453543988;
 
 // Check if large int prompts work
 a = x+1;
+
+// Check negative number functioning
+def b = (-8);
+b*4 = c;

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,5 +1,5 @@
 /* An script to test out large integer arithmetic. x must be
-   342342428479792353453543986 and c must be -32. Run
+   342342428479792353453543986, c must be -32, and f must be -68. Run
    as follows:
    vamp-ir setup params.pp
    vamp-ir compile tests/ints.pir params.pp circuit.plonk
@@ -20,3 +20,6 @@ a = x+1;
 // Check negative number functioning
 def b = (-8);
 b*4 = c;
+
+// Check alternative radixes
+f = 0x22 * (-0b10);


### PR DESCRIPTION
Made the changes regarding valid int literals in vampir. The changes are as follows:
* Negative integer literals in the prover prompt can now be parsed
* Added support for large integers in vampir source files
* Added some test to exercise this large integer facility

Bincode serialization code was added in order to support serialization of ASTs containing `BigInts`.