### PR TITLE
Fixed the bug of variable names starting with capitals not parsing.

### DIFF
--- a/src/synth.rs
+++ b/src/synth.rs
@@ -782,6 +782,10 @@ where
     }
 
     fn padded_circuit_size(&self) -> usize {
-        self.module.exprs.len().next_power_of_two()
+        // The with_expected_size function adds the following gates:
+        // 1 gate to constrain the zero variable to equal 0
+        // 3 gates to add blinging factors to the circuit polynomials
+        const BUILTIN_GATE_COUNT: usize = 4;
+        (self.module.exprs.len()+BUILTIN_GATE_COUNT).next_power_of_two()
     }
 }

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -2,11 +2,11 @@ WHITESPACE = _{ " " | "\t" | NEWLINE }
 
 COMMENT = _{ "//" ~ (!"\n" ~ ANY)* | "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
-lowercaseIdent = @{ (ASCII_ALPHA_LOWER | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+ident = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 keyword = { "fun" | "def" }
 
-valueName = { !keyword ~ lowercaseIdent }
+valueName = { !keyword ~ ident }
 
 infixOp = { "/" | "*" | "+" | "-" | "=" | "^" | "\\" | "%" }
 

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -235,3 +235,5 @@ def rem a b { snd (divrem a b) };
 (4,1) = divrem 9 2;
 
 range4 15;
+
+def D = 10;


### PR DESCRIPTION
There's a bug where variable names beginning with capital letters don't parse. This pull request fixes it and augments an example in order to test this fix.