### PR TITLE
Murisi/cli args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +238,12 @@ checksum = "913287a8f3e00db4c7ae1b87e9b9b8cebd6b89217eaadfc281fa5c897da35dc3"
 dependencies = [
  "virtue",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -277,6 +294,43 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -420,6 +474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "paste"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,12 +711,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.37"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "unicode-xid",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -761,6 +851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +883,15 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -844,6 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +978,7 @@ dependencies = [
  "ark-poly-commit",
  "ark-serialize",
  "bincode",
+ "clap",
  "num-bigint",
  "pest",
  "pest_derive",
@@ -892,6 +1004,37 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ark-ed-on-bls12-381 = "0.3"
 ark-poly = "0.3"
 ark-poly-commit = "0.3"
 ark-serialize = "0.3.0"
+clap = { version = "4.0.17", features = [ "derive" ] }
 num-bigint = "^0.4.0"
 bincode = "2.0.0-rc.1"
 rand_core = "0.6.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,91 @@ use plonk_core::proof_system::{ProverKey, VerifierKey, Proof};
 use plonk_core::proof_system::pi::PublicInputs;
 use bincode::error::{DecodeError, EncodeError};
 use ark_serialize::{Read, SerializationError};
+use clap::{Args, Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Sets up the public parameters required for proving
+    Setup(Setup),
+    /// Compiles a given source file to a circuit
+    Compile(Compile),
+    /// Proves knowledge of witnesses satisfying a circuit
+    Prove(Prove),
+    /// Verifies that a proof is a correct one
+    Verify(Verify),
+}
+
+#[derive(Args)]
+struct Setup {
+    /// Maximum degree exponent of the polynomial commitment scheme
+    #[arg(short, long)]
+    max_degree: u128,
+    /// Path to which the public parameters are written
+    #[arg(short, long)]
+    output: PathBuf,
+    /// Disable validity checks on the generated public parameters
+    #[arg(long)]
+    unchecked: bool,
+}
+
+#[derive(Args)]
+struct Compile {
+    /// Path to public parameters
+    #[arg(short, long)]
+    universal_params: PathBuf,
+    /// Path to source file to be compiled
+    #[arg(short, long)]
+    source: PathBuf,
+    /// Path to which circuit is written
+    #[arg(short, long)]
+    output: PathBuf,
+    /// Do not perform validity checks on public parameters
+    #[arg(long)]
+    unchecked: bool,
+}
+
+#[derive(Args)]
+struct Prove {
+    /// Path to public parameters
+    #[arg(short, long)]
+    universal_params: PathBuf,
+    /// Path to circuit on which to construct proof
+    #[arg(short, long)]
+    circuit: PathBuf,
+    /// Path to which the proof is written
+    #[arg(short, long)]
+    output: PathBuf,
+    /// Do not perform validity checks on public parameters
+    #[arg(long)]
+    unchecked: bool,
+}
+
+#[derive(Args)]
+struct Verify {
+    /// Path to public parameters
+    #[arg(short, long)]
+    universal_params: PathBuf,
+    /// Path to circuit on which to construct proof
+    #[arg(short, long)]
+    circuit: PathBuf,
+    /// Path to the proof that is being verified
+    #[arg(short, long)]
+    proof: PathBuf,
+    /// Do not perform validity checks on public parameters
+    #[arg(long)]
+    unchecked: bool,
+}
 
 type PC = SonicKZG10<Bls12_381, DensePolynomial<BlsScalar>>;
+type UniversalParams = <PC as PolynomialCommitment<<Bls12_381 as PairingEngine>::Fr, DensePolynomial<BlsScalar>>>::UniversalParams;
 
 /* Captures all the data required to use a circuit. */
 struct CircuitData {
@@ -102,50 +185,37 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
     var_assignments
 }
 
-/* Implements the subcommand that tells user how to use this program. */
-fn usage_cmd() {
-    println!("Vampir Aliased Multivariate Polynomial Intermediate Representation");
-    println!("usage 1: vamp-ir setup");
-    println!("usage 2: vamp-ir compile");
-    println!("usage 3: vamp-ir prove");
-    println!("usage 4: vamp-ir verify");
-}
-
 /* Implements the subcommand that generates the public parameters for proofs. */
-fn setup_cmd(args: &[String]) {
-    if args.len() < 1 {
-        println!("usage: vamp-ir setup params.pp");
-        println!("randomly generates public parameters and saves them into params.pp");
-        return;
-    }
+fn setup_cmd(Setup { max_degree, output, unchecked }: &Setup) {
     // Generate CRS
     println!("* Setting up public parameters...");
-    let pp = PC::setup(1 << 10, None, &mut OsRng)
+    let pp = PC::setup(1 << max_degree, None, &mut OsRng)
         .map_err(to_pc_error::<BlsScalar, PC>)
         .expect("unable to setup polynomial commitment scheme public parameters");
-    let mut pp_file = File::create(args[0].clone())
+    let mut pp_file = File::create(output)
         .expect("unable to create public parameters file");
-    pp.serialize(&mut pp_file).unwrap();
+    if *unchecked {
+        pp.serialize_unchecked(&mut pp_file)
+    } else {
+        pp.serialize(&mut pp_file)
+    }.unwrap();
     println!("* Public parameter setup success!");
 }
 
 /* Implements the subcommand that compiles a vamp-ir file into a PLONK circuit.
  */
-fn compile_cmd(args: &[String]) {
-    if args.len() < 3 {
-        println!("usage: vamp-ir compile source.pir params.pp circuit.plonk");
-        println!("reads the vamp-ir source code in source.pir and the public\n\
-                  parameters at params.pp and compiles them into a circuit which\n\
-                  is stored at circuit.plonk .");
-        return;
-    }
+fn compile_cmd(Compile { universal_params, source, output, unchecked }: &Compile) {
     println!("* Reading public parameters...");
-    let mut pp_file = File::open(args[1].clone())
+    let mut pp_file = File::open(universal_params)
         .expect("unable to load public parameters file");
-    let pp = <PC as PolynomialCommitment<<Bls12_381 as PairingEngine>::Fr, DensePolynomial<BlsScalar>>>::UniversalParams::deserialize(&mut pp_file).unwrap();
+    let pp = if *unchecked {
+        UniversalParams::deserialize_unchecked(&mut pp_file)
+    } else {
+        UniversalParams::deserialize(&mut pp_file)
+    }.unwrap();
 
     println!("* Compiling constraints...");
-    let unparsed_file = fs::read_to_string(args[0].clone()).expect("cannot read file");
+    let unparsed_file = fs::read_to_string(source).expect("cannot read file");
     let module = Module::parse(&unparsed_file).unwrap();
     let module_3ac = compile(module);
 
@@ -155,7 +225,7 @@ fn compile_cmd(args: &[String]) {
     let (pk_p, vk) = circuit.compile::<PC>(&pp)
         .expect("unable to compile circuit");
     println!("* Serializing circuit to storage...");
-    let mut circuit_file = File::create(args[2].clone())
+    let mut circuit_file = File::create(output)
         .expect("unable to create circuit file");
     CircuitData { pk_p, vk, circuit }.write(&mut circuit_file).unwrap();
 
@@ -164,25 +234,21 @@ fn compile_cmd(args: &[String]) {
 
 /* Implements the subcommand that creates a proof from interactively entered
  * inputs. */
-fn prove_cmd(args: &[String]) {
-    if args.len() < 3 {
-        println!("usage: vamp-ir prove circuit.plonk params.pp proof.plonk");
-        println!("reads the plonk circuit at circuit.plonk and the public\n\
-                  parameters at params.pp, then interactively requests for\n\
-                  private inputs, and then stores the proof at proof.plonk. Note\n\
-                  that this subcommand makes no attempt to verify supplied inputs.");
-        return;
-    }
+fn prove_cmd(Prove { universal_params, circuit, output, unchecked }: &Prove) {
     println!("* Reading arithmetic circuit...");
-    let mut circuit_file = File::open(args[0].clone())
+    let mut circuit_file = File::open(circuit)
         .expect("unable to load circuit file");
     let CircuitData { pk_p, vk: _vk, mut circuit} =
         CircuitData::read(&mut circuit_file).unwrap();
 
     println!("* Reading public parameters...");
-    let mut pp_file = File::open(args[1].clone())
+    let mut pp_file = File::open(universal_params)
         .expect("unable to load public parameters file");
-    let pp = <PC as PolynomialCommitment<<Bls12_381 as PairingEngine>::Fr, DensePolynomial<BlsScalar>>>::UniversalParams::deserialize(&mut pp_file).unwrap();
+    let pp = if *unchecked {
+        UniversalParams::deserialize_unchecked(&mut pp_file)
+    } else {
+        UniversalParams::deserialize(&mut pp_file)
+    }.unwrap();
     // Prover POV
     println!("* Soliciting circuit witnesses...");
     // Prompt for program inputs
@@ -194,7 +260,7 @@ fn prove_cmd(args: &[String]) {
     let (proof, pi) = circuit.gen_proof::<PC>(&pp, pk_p, b"Test").unwrap();
 
     println!("* Serializing proof to storage...");
-    let mut proof_file = File::create(args[2].clone())
+    let mut proof_file = File::create(output)
         .expect("unable to create proof file");
     ProofData { proof, pi }.serialize(&mut proof_file).unwrap();
 
@@ -202,29 +268,26 @@ fn prove_cmd(args: &[String]) {
 }
 
 /* Implements the subcommand that verifies that a proof is correct. */
-fn verify_cmd(args: &[String]) {
-    if args.len() < 3 {
-        println!("usage: vamp-ir verify circuit.plonk params.pp proof.plonk");
-        println!("reads the plonk circuit at circuit.plonk, the public\n\
-                  parameters at params.pp, and the proof at proof.plonk and\n\
-                  verifies whether the proof is a correct one.");
-        return;
-    }
+fn verify_cmd(Verify { universal_params, circuit, proof, unchecked }: &Verify) {
     println!("* Reading arithmetic circuit...");
-    let mut circuit_file = File::open(args[0].clone())
+    let mut circuit_file = File::open(circuit)
         .expect("unable to load circuit file");
     let CircuitData { pk_p: _pk_p, vk, circuit: _circuit} =
         CircuitData::read(&mut circuit_file).unwrap();
 
     println!("* Reading zero-knowledge proof...");
-    let mut proof_file = File::open(args[2].clone())
+    let mut proof_file = File::open(proof)
         .expect("unable to load proof file");
     let ProofData { proof, pi } = ProofData::deserialize(&mut proof_file).unwrap();
 
     println!("* Reading public parameters...");
-    let mut pp_file = File::open(args[1].clone())
+    let mut pp_file = File::open(universal_params)
         .expect("unable to load public parameters file");
-    let pp = <PC as PolynomialCommitment<<Bls12_381 as PairingEngine>::Fr, DensePolynomial<BlsScalar>>>::UniversalParams::deserialize(&mut pp_file).unwrap();
+    let pp = if *unchecked {
+        UniversalParams::deserialize_unchecked(&mut pp_file)
+    } else {
+        UniversalParams::deserialize(&mut pp_file)
+    }.unwrap();
     
     // Verifier POV
     println!("* Verifying proof validity...");
@@ -245,18 +308,19 @@ fn verify_cmd(args: &[String]) {
 
 /* Main entry point for vamp-ir compiler, prover, and verifier. */
 fn main() {
-    let args: Vec<_> = std::env::args().collect();
-    if args.len() < 2 {
-        usage_cmd();
-    } else if args[1] == "setup" {
-        setup_cmd(&args[2..]);
-    } else if args[1] == "compile" {
-        compile_cmd(&args[2..]);
-    } else if args[1] == "prove" {
-        prove_cmd(&args[2..]);
-    } else if args[1] == "verify" {
-        verify_cmd(&args[2..]);
-    } else {
-        usage_cmd();
+    let cli = Cli::parse();
+    match &cli.command {
+        Commands::Setup(args) => {
+            setup_cmd(args);
+        },
+        Commands::Compile(args) => {
+            compile_cmd(args);
+        },
+        Commands::Prove(args) => {
+            prove_cmd(args);
+        },
+        Commands::Verify(args) => {
+            verify_cmd(args);
+        },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ enum Commands {
 #[derive(Args)]
 struct Setup {
     /// Maximum degree exponent of the polynomial commitment scheme
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = 10)]
     max_degree: u128,
     /// Path to which the public parameters are written
     #[arg(short, long)]

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -782,6 +782,6 @@ where
     }
 
     fn padded_circuit_size(&self) -> usize {
-        1 << 10
+        self.module.exprs.len().next_power_of_two()
     }
 }

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -1,9 +1,9 @@
 /* An implementation of standard arithmetic logic unit operations in vampir. Run
    as follows:
-   vamp-ir setup params.pp
-   vamp-ir compile tests/alu.pir params.pp circuit.plonk
-   vamp-ir prove circuit.plonk params.pp proof.plonk
-   vamp-ir verify circuit.plonk params.pp proof.plonk
+   vamp-ir setup -m 10 -o params.pp
+   vamp-ir compile -u params.pp -s tests/alu.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */
 
 // Pair up corresponding elements of each tuple

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -1,6 +1,6 @@
 /* An implementation of standard arithmetic logic unit operations in vampir. Run
    as follows:
-   vamp-ir setup -m 10 -o params.pp
+   vamp-ir setup -o params.pp
    vamp-ir compile -u params.pp -s tests/alu.pir -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk

--- a/tests/bool.pir
+++ b/tests/bool.pir
@@ -1,5 +1,5 @@
 /* a must either be 0 or 1. Run as follows:
-   vamp-ir setup -m 10 -o params.pp
+   vamp-ir setup -o params.pp
    vamp-ir compile -u params.pp -s tests/bool.pir -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk

--- a/tests/bool.pir
+++ b/tests/bool.pir
@@ -1,8 +1,8 @@
 /* a must either be 0 or 1. Run as follows:
-   vamp-ir setup params.pp
-   vamp-ir compile tests/bool.pir params.pp circuit.plonk
-   vamp-ir prove circuit.plonk params.pp proof.plonk
-   vamp-ir verify circuit.plonk params.pp proof.plonk
+   vamp-ir setup -m 10 -o params.pp
+   vamp-ir compile -u params.pp -s tests/bool.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */
 // defining a constant
 def myval = 0;

--- a/tests/funcs.pir
+++ b/tests/funcs.pir
@@ -1,8 +1,8 @@
 /* Any solution such that b=c, d=e, and f=g is valid. Run as follows:
-   vamp-ir setup params.pp
-   vamp-ir compile tests/funcs.pir params.pp circuit.plonk
-   vamp-ir prove circuit.plonk params.pp proof.plonk
-   vamp-ir verify circuit.plonk params.pp proof.plonk
+   vamp-ir setup -m 10 -o params.pp
+   vamp-ir compile -u params.pp -s tests/funcs.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
    */
 // defining a two parameter function.
 // function body contains two constraints.

--- a/tests/funcs.pir
+++ b/tests/funcs.pir
@@ -1,5 +1,5 @@
 /* Any solution such that b=c, d=e, and f=g is valid. Run as follows:
-   vamp-ir setup -m 10 -o params.pp
+   vamp-ir setup -o params.pp
    vamp-ir compile -u params.pp -s tests/funcs.pir -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk

--- a/tests/pyt.pir
+++ b/tests/pyt.pir
@@ -1,8 +1,8 @@
 /* Any numbers a,b such that a^2+b^2=25 yield valid proofs. Run as follows:
-   vamp-ir setup params.pp
-   vamp-ir compile tests/pyt.pir params.pp circuit.plonk
-   vamp-ir prove circuit.plonk params.pp proof.plonk
-   vamp-ir verify circuit.plonk params.pp proof.plonk
+   vamp-ir setup -m 10 -o params.pp
+   vamp-ir compile -u params.pp -s tests/pyt.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
    */
 // computation + BIDMAS
 def pyt a b { a^2 + b^2 };

--- a/tests/pyt.pir
+++ b/tests/pyt.pir
@@ -1,5 +1,5 @@
 /* Any numbers a,b such that a^2+b^2=25 yield valid proofs. Run as follows:
-   vamp-ir setup -m 10 -o params.pp
+   vamp-ir setup -o params.pp
    vamp-ir compile -u params.pp -s tests/pyt.pir -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -1,8 +1,8 @@
 /* Any value 0 <= x < 32 such that the last two bits 1, 0 is valid. For example
    10 is valid since its bit string is ...1010. Run as follows:
-   vamp-ir setup params.pp
-   vamp-ir compile tests/range.pir params.pp circuit.plonk
-   vamp-ir prove circuit.plonk params.pp proof.plonk
-   vamp-ir verify circuit.plonk params.pp proof.plonk
+   vamp-ir setup -m 10 -o params.pp
+   vamp-ir compile -u params.pp -s tests/range.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */
 def (0, 1, ar) = range 5 x;

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -1,6 +1,6 @@
 /* Any value 0 <= x < 32 such that the last two bits 1, 0 is valid. For example
    10 is valid since its bit string is ...1010. Run as follows:
-   vamp-ir setup -m 10 -o params.pp
+   vamp-ir setup -o params.pp
    vamp-ir compile -u params.pp -s tests/range.pir -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk

--- a/tests/tuples.pir
+++ b/tests/tuples.pir
@@ -1,10 +1,10 @@
 /* Any assignment such that the sets {q.0, q.1, q.2, q.3} =
    {0, 1} and r.0.0=r.0.1, r.1.0=r.1.1, r.2.0=r.2.1, r.3.0=r.3.1
    is valid. Run as follows:
-   vamp-ir setup params.pp
-   vamp-ir compile tests/tuples.pir params.pp circuit.plonk
-   vamp-ir prove circuit.plonk params.pp proof.plonk
-   vamp-ir verify circuit.plonk params.pp proof.plonk
+   vamp-ir setup -m 10 -o params.pp
+   vamp-ir compile -u params.pp -s tests/tuples.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */
 // define higher order function
 def map f (a,b,c,d) {

--- a/tests/tuples.pir
+++ b/tests/tuples.pir
@@ -1,7 +1,7 @@
 /* Any assignment such that the sets {q.0, q.1, q.2, q.3} =
    {0, 1} and r.0.0=r.0.1, r.1.0=r.1.1, r.2.0=r.2.1, r.3.0=r.3.1
    is valid. Run as follows:
-   vamp-ir setup -m 10 -o params.pp
+   vamp-ir setup -o params.pp
    vamp-ir compile -u params.pp -s tests/tuples.pir -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk


### PR DESCRIPTION
Altered the compiler's command line interface as follows:
* Changed the syntax of the arguments to that of the Clap library
* Now provide CLI flag to allow users to setup and load unchecked parameters
* Parameterize the public parameter setup to take the maximum size from the user
* Altered the synthesizer to yield a padded circuit size informed by the circuit