### PR TITLE
Allow vampir numbers to be specified in alternative bases.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,6 +7,8 @@ use bincode::{Encode, Decode};
 use std::collections::{HashMap, HashSet};
 use crate::transform::VarGen;
 use num_bigint::BigInt;
+use num_traits::Num;
+use std::ops::Neg;
 #[derive(Parser)]
 #[grammar = "vampir.pest"]
 pub struct VampirParser;
@@ -507,6 +509,33 @@ impl :: bincode :: Decode for Expr
     }
 }
 
+/* Parse signed integer literals beginning with at most one occurrence of 0x
+ * (indicating a radix of 16), 0o (radix 8), or 0b (radix 2). */
+pub fn parse_prefixed_num<T>(string: &str) -> Result<T, T::FromStrRadixErr>
+where T: Num + Neg<Output = T> {
+    // Process the number's sign
+    let (pos, magnitude) =
+        if let Some(rest) = string.strip_prefix("-") {
+            (false, rest)
+        } else if let Some(rest) = string.strip_prefix("+") {
+            (true, rest)
+        } else {
+            (true, string)
+        };
+    // Process the number's radix
+    let magnitude = if let Some(rest) = magnitude.strip_prefix("0b") {
+        T::from_str_radix(rest, 2)
+    } else if let Some(rest) = magnitude.strip_prefix("0o") {
+        T::from_str_radix(rest, 8)
+    } else if let Some(rest) = magnitude.strip_prefix("0x") {
+        T::from_str_radix(rest, 16)
+    } else {
+        T::from_str_radix(magnitude, 10)
+    }?;
+    // Combine magnitude and sign
+    Ok(if pos { magnitude } else { -magnitude })
+}
+
 impl TExpr {
     pub fn parse(pair: Pair<Rule>) -> Option<Self> {
         if pair.as_rule() != Rule::expr { return None }
@@ -661,7 +690,8 @@ impl TExpr {
         if pair.as_rule() == Rule::constant && string.starts_with("(") {
             Some(Expr::Unit.into())
         } else if pair.as_rule() == Rule::constant {
-            let value = pair.as_str().parse().ok().expect("constant should be an integer");
+            let value = parse_prefixed_num(pair.as_str())
+                .expect("constant should be an integer");
             Some(Expr::Constant(value).into())
         } else if pair.as_rule() == Rule::valueName {
             let name = Variable::parse(pair).expect("expression should be value name");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 use std::fs;
-use crate::ast::{Module, VariableId, Pattern};
+use crate::ast::{Module, VariableId, Pattern, parse_prefixed_num};
 use crate::transform::{compile, collect_module_variables};
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ed_on_bls12_381::EdwardsParameters as JubJubParameters;
@@ -28,7 +28,6 @@ use plonk_core::proof_system::{ProverKey, VerifierKey, Proof};
 use plonk_core::proof_system::pi::PublicInputs;
 use bincode::error::{DecodeError, EncodeError};
 use ark_serialize::{Read, SerializationError};
-use num_bigint::BigInt;
 
 type PC = SonicKZG10<Bls12_381, DensePolynomial<BlsScalar>>;
 
@@ -93,11 +92,8 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
         std::io::stdin()
             .read_line(&mut input_line)
             .expect("failed to read input");
-        let x: BigInt = if let Ok(x) = input_line.trim().parse() {
-            x
-        } else {
-            panic!("input not an integer");
-        };
+        let x = parse_prefixed_num(input_line.trim())
+            .expect("input not an integer");
         var_assignments.insert(id, make_constant(&x));
     }
     var_assignments

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -10,7 +10,13 @@ valueName = { !keyword ~ lowercaseIdent }
 
 infixOp = { "/" | "*" | "+" | "-" | "=" | "^" }
 
-integerLiteral = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+binary = @{ '0'..'1' }
+
+octal = @{ '0'..'7' }
+
+hexadecimal = @{ '0'..'9' | 'a'..'f' | 'A'..'F' }
+
+integerLiteral = @{ "0x" ~ hexadecimal+ | "0o" ~ octal+ | "0b" ~ binary+ | ASCII_DIGIT+ }
 
 constant = { integerLiteral | "(" ~ ")" }
 

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,5 +1,5 @@
 /* An script to test out large integer arithmetic. x must be
-   342342428479792353453543986 and c must be -32. Run
+   342342428479792353453543986, c must be -32, and f must be -68. Run
    as follows:
    vamp-ir setup params.pp
    vamp-ir compile tests/ints.pir params.pp circuit.plonk
@@ -20,3 +20,6 @@ a = x+1;
 // Check negative number functioning
 def b = (-8);
 b*4 = c;
+
+// Check alternative radixes
+f = 0x22 * (-0b10);


### PR DESCRIPTION
Added support for vampir source files to contain number literals in alternative bases by using prefixes. Specifically:
* 0x for hexadecimal numbers
* 0b for binary numbers
* 0o for octal numbers
* none for decimal numbers

Additionally, the prover interactive input also supports signed numbers in this form.