### PR TITLE
Split compile command

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fmt::Write;
 use crate::typecheck::Type;
 use crate::pest::Parser;
-use bincode::{Encode, Decode};
+use bincode::{Encode, Decode, error::{EncodeError, DecodeError}};
 use std::collections::{HashMap, HashSet};
 use crate::transform::VarGen;
 #[derive(Parser)]
@@ -49,6 +49,22 @@ impl Module {
             }
         }
         unreachable!("EOI should have been encountered")
+    }
+    pub fn read<R>(mut reader: R) -> Result<Self, DecodeError>
+    where
+        R: std::io::Read,
+    {
+        let module: Module =
+            bincode::decode_from_std_read(&mut reader, bincode::config::standard())?;
+        Ok(module)
+    }
+
+    pub fn write<W>(&self, mut writer: W) -> Result<(), EncodeError>
+    where
+        W: std::io::Write,
+    {
+        bincode::encode_into_std_write(&self, &mut writer, bincode::config::standard())?;
+        Ok(())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,6 @@ fn setup_cmd(Setup { max_degree, output, unchecked }: &Setup) {
     println!("* Public parameter setup success!");
 }
 
-
 /* Implements the subcommand that compiles a vamp-ir file into a PLONK circuit.
  */
 fn compile_cmd(Compile { source, output }: &Compile) {

--- a/tests/alu.pir
+++ b/tests/alu.pir
@@ -1,7 +1,8 @@
 /* An implementation of standard arithmetic logic unit operations in vampir. Run
    as follows:
    vamp-ir setup -o params.pp
-   vamp-ir compile -u params.pp -s tests/alu.pir -o circuit.plonk
+   vamp-ir compile -s test/alu.pir -o alu.circ
+   vamp-ir synth -u params.pp -s alu.circ -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */

--- a/tests/bool.pir
+++ b/tests/bool.pir
@@ -1,6 +1,7 @@
 /* a must either be 0 or 1. Run as follows:
    vamp-ir setup -o params.pp
-   vamp-ir compile -u params.pp -s tests/bool.pir -o circuit.plonk
+   vamp-ir compile -s test/bool.pir -o bool.circ
+   vamp-ir synth -u params.pp -s bool.circ -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */

--- a/tests/funcs.pir
+++ b/tests/funcs.pir
@@ -1,6 +1,7 @@
 /* Any solution such that b=c, d=e, and f=g is valid. Run as follows:
    vamp-ir setup -o params.pp
-   vamp-ir compile -u params.pp -s tests/funcs.pir -o circuit.plonk
+   vamp-ir compile -s test/funcs.pir -o funcs.circ
+   vamp-ir synth -u params.pp -s funcs.circ -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
    */

--- a/tests/pyt.pir
+++ b/tests/pyt.pir
@@ -1,6 +1,7 @@
 /* Any numbers a,b such that a^2+b^2=25 yield valid proofs. Run as follows:
    vamp-ir setup -o params.pp
-   vamp-ir compile -u params.pp -s tests/pyt.pir -o circuit.plonk
+   vamp-ir compile -s test/pyt.pir -o pyt.circ
+   vamp-ir synth -u params.pp -s pyt.circ -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
    */

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -1,7 +1,8 @@
 /* Any value 0 <= x < 32 such that the last two bits 1, 0 is valid. For example
    10 is valid since its bit string is ...1010. Run as follows:
    vamp-ir setup -o params.pp
-   vamp-ir compile -u params.pp -s tests/range.pir -o circuit.plonk
+   vamp-ir compile -s test/range.pir -o range.circ
+   vamp-ir synth -u params.pp -s range.circ -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */

--- a/tests/tuples.pir
+++ b/tests/tuples.pir
@@ -2,7 +2,8 @@
    {0, 1} and r.0.0=r.0.1, r.1.0=r.1.1, r.2.0=r.2.1, r.3.0=r.3.1
    is valid. Run as follows:
    vamp-ir setup -o params.pp
-   vamp-ir compile -u params.pp -s tests/tuples.pir -o circuit.plonk
+   vamp-ir compile -s test/tuples.pir -o tuples.circ
+   vamp-ir synth -u params.pp -s tuples.circ -o circuit.plonk
    vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
    vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
 */


### PR DESCRIPTION
Addresses #19

Splits `compile` into two commands:
1. `compile`, which accepts vamp-ir code and creates a backend-agnostic representation of an arithmetic circuit in three-address code format (3ac)
2. `synth`, which accepts a circuit in 3ac and public parameters and produces a circuit in zk-garage/plonk format