### PR TITLE
Murisi/literals2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "bincode",
  "clap",
  "num-bigint",
+ "num-traits",
  "pest",
  "pest_derive",
  "plonk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ark-poly-commit = "0.3"
 ark-serialize = "0.3.0"
 clap = { version = "4.0.17", features = [ "derive" ] }
 num-bigint = "^0.4.0"
+num-traits = "^0.2.14"
 bincode = "2.0.0-rc.1"
 rand_core = "0.6.3"
 plonk = { git = "https://github.com/ZK-Garage/plonk", rev = "ec76fd3" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 use std::fs;
-use crate::ast::{Module, VariableId, Pat};
+use crate::ast::{Module, VariableId, Pat, parse_prefixed_num};
 use crate::transform::{compile, collect_module_variables};
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ed_on_bls12_381::EdwardsParameters as JubJubParameters;
@@ -18,7 +18,7 @@ use plonk::error::to_pc_error;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use plonk_core::prelude::VerifierData;
-use crate::synth::PlonkModule;
+use crate::synth::{PlonkModule, make_constant};
 use plonk_core::circuit::Circuit;
 use ark_ff::PrimeField;
 use std::fs::File;
@@ -184,12 +184,9 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
         std::io::stdin()
             .read_line(&mut input_line)
             .expect("failed to read input");
-        let x: F = if let Ok(x) = input_line.trim().parse() {
-            x
-        } else {
-            panic!("input not an integer");
-        };
-        var_assignments.insert(id, x);
+        let x = parse_prefixed_num(input_line.trim())
+            .expect("input not an integer");
+        var_assignments.insert(id, make_constant(&x));
     }
     var_assignments
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 use std::fs;
-use crate::ast::{Module, VariableId, Pattern};
+use crate::ast::{Module, VariableId, Pat};
 use crate::transform::{compile, collect_module_variables};
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ed_on_bls12_381::EdwardsParameters as JubJubParameters;
@@ -161,7 +161,7 @@ fn prompt_inputs<F>(annotated: &Module) -> HashMap<VariableId, F> where F: Prime
     collect_module_variables(&annotated, &mut input_variables);
     // Defined variables should not be requested from user
     for def in &annotated.defs {
-        if let Pattern::Variable(var) = &def.0.0 {
+        if let Pat::Variable(var) = &def.0.0.v {
             input_variables.remove(&var.id);
         }
     }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Module, VariableId, TExpr, InfixOp, Pattern, Expr};
+use crate::ast::{Module, VariableId, TExpr, InfixOp, Pat, Expr};
 use crate::transform::collect_module_variables;
 use ark_ff::PrimeField;
 use ark_ec::TEModelParameters;
@@ -37,11 +37,11 @@ impl<T> bincode::Decode for PrimeFieldBincode<T> where T: PrimeField {
 }
 
 // Make field elements from signed values
-fn make_constant<F: PrimeField>(c: i32) -> F {
+fn make_constant<F: PrimeField>(c: i128) -> F {
     if c >= 0 {
-        F::from(c as u32)
+        F::from(c as u128)
     } else {
-        -F::from((-c) as u32)
+        -F::from((-c) as u128)
     }
 }
 
@@ -154,13 +154,13 @@ where
         // Get the definitions necessary to populate auxiliary variables
         let mut definitions = HashMap::new();
         for def in &self.module.defs {
-            if let Pattern::Variable(var) = &def.0.0 {
+            if let Pat::Variable(var) = &def.0.0.v {
                 definitions.insert(var.id, *def.0.1.clone());
             }
         }
         // Start deriving witnesses
         for (var, value) in &mut self.variable_map {
-            let var_expr = Expr::Variable(crate::ast::Variable::new(*var)).into();
+            let var_expr = Expr::Variable(crate::ast::Variable::new(*var)).type_expr(None);
             *value = evaluate_expr(&var_expr, &mut definitions, &mut field_assigns);
         }
     }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -8,7 +8,8 @@ use plonk_core::error::Error;
 use plonk_core::proof_system::pi::PublicInputs;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
-use num_bigint::BigUint;
+use num_bigint::{BigUint, BigInt};
+use num_traits::Signed;
 use crate::ast::Variable;
 
 struct PrimeFieldBincode<T>(T) where T: PrimeField;
@@ -37,11 +38,12 @@ impl<T> bincode::Decode for PrimeFieldBincode<T> where T: PrimeField {
 }
 
 // Make field elements from signed values
-fn make_constant<F: PrimeField>(c: i128) -> F {
-    if c >= 0 {
-        F::from(c as u128)
+pub fn make_constant<F: PrimeField>(c: &BigInt) -> F {
+    let magnitude = F::from(c.magnitude().clone());
+    if c.is_positive() {
+        magnitude
     } else {
-        -F::from((-c) as u128)
+        -magnitude
     }
 }
 
@@ -52,7 +54,7 @@ fn evaluate_expr<F>(
     assigns: &mut HashMap<VariableId, F>,
 ) -> F where F: PrimeField {
     match &expr.v {
-        Expr::Constant(c) => make_constant(*c),
+        Expr::Constant(c) => make_constant(c),
         Expr::Variable(v) => {
             if let Some(val) = assigns.get(&v.id) {
                 // First look for existing variable assignment
@@ -235,7 +237,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c2))
+                                .constant(make_constant(&-c2))
                         });
                     },
                     // v1 = -c2
@@ -246,7 +248,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(*c2))
+                                .constant(make_constant(c2))
                         });
                         true
                     }) => {},
@@ -272,7 +274,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c2-c3))
+                                .constant(make_constant(&(-c2-c3)))
                         });
                         true
                     }) => {},
@@ -287,7 +289,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(-c3))
+                                .constant(make_constant(&-c3))
                         });
                         true
                     }) => {},
@@ -302,7 +304,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(-c2))
+                                .constant(make_constant(&-c2))
                         });
                         true
                     }) => {},
@@ -332,7 +334,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c2+c3))
+                                .constant(make_constant(&(-c2+c3)))
                         });
                         true
                     }) => {},
@@ -347,7 +349,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(*c3))
+                                .constant(make_constant(c3))
                         });
                         true
                     }) => {},
@@ -362,7 +364,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), F::one())
-                                .constant(make_constant(-c2))
+                                .constant(make_constant(&-c2))
                         });
                         true
                     }) => {},
@@ -389,8 +391,8 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c2);
-                        let op2: F = make_constant(*c3);
+                        let op1: F = make_constant(c2);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
@@ -406,7 +408,7 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op2: F = make_constant(*c3);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -(F::one()/op2))
@@ -421,7 +423,7 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c2);
+                        let op1: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .mul(F::one())
@@ -452,8 +454,8 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c2);
-                        let op2: F = make_constant(*c3);
+                        let op1: F = make_constant(c2);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
@@ -469,7 +471,7 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op2: F = make_constant(*c3);
+                        let op2: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v2.id], Some(zero))
                                 .add(F::one(), -op2)
@@ -484,7 +486,7 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op2: F = make_constant(*c2);
+                        let op2: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v1.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -op2)
@@ -515,7 +517,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-c1))
+                                .constant(make_constant(&-c1))
                         });
                     },
                     // c1 = c2
@@ -526,7 +528,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c2-c1))
+                                .constant(make_constant(&(c2-c1)))
                         });
                     },
                     // c1 = -c2
@@ -537,7 +539,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c1+*c2))
+                                .constant(make_constant(&(c1+c2)))
                         });
                         true
                     }) => {},
@@ -549,7 +551,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(*c1))
+                                .constant(make_constant(c1))
                         });
                         true
                     }) => {},
@@ -564,7 +566,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c1-c2-c3))
+                                .constant(make_constant(&(c1-c2-c3)))
                         });
                         true
                     }) => {},
@@ -579,7 +581,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(c3-c1))
+                                .constant(make_constant(&(c3-c1)))
                         });
                         true
                     }) => {},
@@ -594,7 +596,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(c2-c1))
+                                .constant(make_constant(&(c2-c1)))
                         });
                         true
                     }) => {},
@@ -609,7 +611,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), F::one())
-                                .constant(make_constant(-c1))
+                                .constant(make_constant(&-c1))
                         });
                         true
                     }) => {},
@@ -624,7 +626,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
-                                .constant(make_constant(c2-c3-c1))
+                                .constant(make_constant(&(c2-c3-c1)))
                         });
                         true
                     }) => {},
@@ -639,7 +641,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(-*c3-c1))
+                                .constant(make_constant(&(-c3-c1)))
                         });
                         true
                     }) => {},
@@ -654,7 +656,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
-                                .constant(make_constant(c1-c2))
+                                .constant(make_constant(&(c1-c2)))
                         });
                         true
                     }) => {},
@@ -669,7 +671,7 @@ where
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -F::one())
-                                .constant(make_constant(-c1))
+                                .constant(make_constant(&-c1))
                         });
                         true
                     }) => {},
@@ -681,9 +683,9 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
@@ -699,8 +701,8 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(F::one(), F::zero())
@@ -716,8 +718,8 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .constant(-(op2/op1))
@@ -732,7 +734,7 @@ where
                         Expr::Variable(v2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
+                        let op1: F = make_constant(c1);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .add(F::one(), -op1)
@@ -747,9 +749,9 @@ where
                         Expr::Constant(c2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(zero, zero, Some(zero))
                                 .add(F::zero(), F::zero())
@@ -765,8 +767,8 @@ where
                         Expr::Variable(v2),
                         Expr::Constant(c3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op3: F = make_constant(*c3);
+                        let op1: F = make_constant(c1);
+                        let op3: F = make_constant(c3);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], zero, Some(zero))
                                 .add(op3, F::zero())
@@ -782,8 +784,8 @@ where
                         Expr::Constant(c2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
-                        let op2: F = make_constant(*c2);
+                        let op1: F = make_constant(c1);
+                        let op2: F = make_constant(c2);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v3.id], zero, Some(zero))
                                 .add(op2, F::zero())
@@ -799,7 +801,7 @@ where
                         Expr::Variable(v2),
                         Expr::Variable(v3),
                     ) if {
-                        let op1: F = make_constant(*c1);
+                        let op1: F = make_constant(c1);
                         composer.arithmetic_gate(|gate| {
                             gate.witness(inputs[&v2.id], inputs[&v3.id], Some(zero))
                                 .mul(F::one())

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
-use crate::ast::{Module, VariableId, Pattern, Variable, TExpr, InfixOp, Function, Definition, Expr, LetBinding, Intrinsic};
+use crate::ast::{Module, VariableId, Pat, TPat, Variable, TExpr, InfixOp, Function, Definition, Expr, LetBinding, Intrinsic};
 use crate::transform::{VarGen, collect_pattern_variables};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use bincode::{Decode, Encode};
 
 /* Collect the free variables occuring in the given type. */
@@ -29,6 +29,26 @@ fn collect_free_type_vars(
     }
 }
 
+/* Generate a unique type variables for each pattern. */
+fn allocate_pat_types(
+    pat: &mut TPat,
+    gen: &mut VarGen,
+) {
+    let new_var = gen.generate_id();
+    pat.t = Some(Type::Variable(Variable::new(new_var)));
+    
+    match &mut pat.v {
+        Pat::Product(pat1, pat2) => {
+            allocate_pat_types(pat1, gen);
+            allocate_pat_types(pat2, gen);
+        },
+        Pat::As(pat1, _) => {
+            allocate_pat_types(pat1, gen);
+        },
+        Pat::Constant(_) | Pat::Variable(_) | Pat::Unit => {},
+    }
+}
+
 /* Generate a unique type variables for each expression. */
 fn allocate_expr_types(
     expr: &mut TExpr,
@@ -38,7 +58,7 @@ fn allocate_expr_types(
     expr.t = Some(Type::Variable(Variable::new(new_var)));
     
     match &mut expr.v {
-        Expr::Sequence(exprs) | Expr::Intrinsic(Intrinsic { args: exprs, .. }) => {
+        Expr::Sequence(exprs) => {
             for expr in exprs {
                 allocate_expr_types(expr, gen);
             }
@@ -52,19 +72,27 @@ fn allocate_expr_types(
             allocate_expr_types(expr1, gen);
         },
         Expr::Function(fun) => {
-            allocate_expr_types(&mut *fun.1, gen);
+            for param in &mut fun.params {
+                allocate_pat_types(param, gen);
+            }
+            allocate_expr_types(&mut *fun.body, gen);
         },
         Expr::LetBinding(binding, body) => {
+            allocate_pat_types(&mut binding.0, gen);
             allocate_expr_types(&mut *binding.1, gen);
             allocate_expr_types(body, gen);
         },
         Expr::Match(matche) => {
             allocate_expr_types(&mut matche.0, gen);
+            for pat1 in &mut matche.1 {
+                allocate_pat_types(pat1, gen);
+            }
             for expr2 in &mut matche.2 {
                 allocate_expr_types(expr2, gen);
             }
         },
-        Expr::Constant(_) | Expr::Variable(_) | Expr::Unit => {},
+        Expr::Constant(_) | Expr::Variable(_) | Expr::Unit |
+        Expr::Intrinsic(_) => {},
     }
 }
 
@@ -73,6 +101,7 @@ fn allocate_def_types(
     def: &mut Definition,
     gen: &mut VarGen,
 ) {
+    allocate_pat_types(&mut def.0.0, gen);
     allocate_expr_types(&mut *def.0.1, gen);
 }
 
@@ -115,64 +144,8 @@ impl Display for Type {
 }
 
 /* Get or generate the type variable associated with a given expression. */
-fn expr_type_var(expr: &TExpr) -> &Type {
+pub fn expr_type_var(expr: &TExpr) -> &Type {
     expr.t.as_ref().unwrap()
-}
-
-/* Generate the type of expressions the given pattern can match. */
-fn pattern_type(pat: &Pattern) -> Type {
-    match pat {
-        Pattern::Unit => Type::Unit,
-        Pattern::Constant(_) => Type::Int,
-        Pattern::Variable(var) => Type::Variable(var.clone()),
-        Pattern::As(pat, _name) => pattern_type(pat),
-        Pattern::Product(pat1, pat2) => {
-            Type::Product(
-                Box::new(pattern_type(pat1)),
-                Box::new(pattern_type(pat2)),
-            )
-        }
-    }
-}
-
-/* Assign each variable in the pattern an explicit type, even if that means
- * expanding upon parts of the given type. */
-fn type_pattern(
-    pat: &Pattern,
-    typ: Type,
-    types: &mut HashMap<VariableId, Type>,
-    gen: &mut VarGen,
-) {
-    match (pat, typ) {
-        (pat, Type::Variable(var)) if types.contains_key(&var.id) =>
-            type_pattern(pat, types[&var.id].clone(), types, gen),
-        (Pattern::Constant(_), typ) =>
-            unify_types(&typ, &Type::Int, types),
-        (Pattern::Variable(var), typ) => {
-            types.insert(var.id, typ.clone());
-        },
-        (Pattern::As(pat, name), typ) => {
-            types.insert(name.id, typ.clone());
-            type_pattern(&pat, typ, types, gen)
-        },
-        (Pattern::Product(pat1, pat2), Type::Product(typ1, typ2)) => {
-            type_pattern(pat1, *typ1.clone(), types, gen);
-            type_pattern(pat2, *typ2.clone(), types, gen);
-        },
-        (Pattern::Product(pat1, pat2), Type::Variable(var)) => {
-            types.insert(var.id, Type::Product(
-                Box::new(Type::Variable(Variable::new(gen.generate_id()))),
-                Box::new(Type::Variable(Variable::new(gen.generate_id()))),
-            ));
-            type_pattern(
-                &Pattern::Product(pat1.clone(), pat2.clone()),
-                Type::Variable(var),
-                types,
-                gen,
-            );
-        },
-        (pat, typ) => panic!("unable to type pattern {} as {}", pat, typ),
-    }
 }
 
 /* Check if the given variable occurs in the type expression. */
@@ -198,42 +171,47 @@ fn unify_variable(
     var1: &Variable,
     type2: &Type,
     types: &mut HashMap<VariableId, Type>,
+    inserts: &mut Option<HashSet<VariableId>>,
 ) {
     match (var1, type2) {
         (var1, Type::Variable(var2)) if var1.id == var2.id => {},
         (var1, type2) if types.contains_key(&var1.id) =>
-            unify_types(&types[&var1.id].clone(), type2, types),
+            unify_types(&types[&var1.id].clone(), type2, types, inserts),
         (var1, Type::Variable(var2)) if types.contains_key(&var2.id) =>
-            unify_types(&Type::Variable(var1.clone()), &types[&var2.id].clone(), types),
+            unify_types(&Type::Variable(var1.clone()), &types[&var2.id].clone(), types, inserts),
         (var1, type2) if !occurs_in(var1, type2, types) => {
             types.insert(var1.id, type2.clone());
+            if let Some(x) = inserts {
+                x.insert(var1.id);
+            }
         }
         _ => panic!("unable to match {:?} with {}", var1, type2),
     }
 }
 
 /* Unify the two given types together. */
-fn unify_types(
+pub fn unify_types(
     type1: &Type,
     type2: &Type,
     types: &mut HashMap<VariableId, Type>,
+    inserts: &mut Option<HashSet<VariableId>>,
 ) {
     match (type1, type2) {
         (Type::Int, Type::Int) |
         (Type::Unit, Type::Unit) => {},
         (Type::Function(a1, b1), Type::Function(a2, b2)) |
         (Type::Product(a1, b1), Type::Product(a2, b2)) => {
-            unify_types(&*a1, &*a2, types);
-            unify_types(&*b1, &*b2, types);
+            unify_types(&*a1, &*a2, types, inserts);
+            unify_types(&*b1, &*b2, types, inserts);
         },
         (Type::Variable(v1), type2) | (type2, Type::Variable(v1)) =>
-            unify_variable(v1, type2, types),
+            unify_variable(v1, type2, types, inserts),
         _ => panic!("unable to match {} with {}", type1, type2),
     }
 }
 
 /* Fully expand the variables in the given type. */
-fn expand_type(
+pub fn expand_type(
     typ: &Type,
     types: &HashMap<VariableId, Type>,
 ) -> Type {
@@ -301,24 +279,73 @@ fn instantiate_type_vars(
     }
 }
 
+/* Refresh all type variables occuring in the given expression that are not
+ * already bound in the type environment. */
+pub fn expand_expr_types(
+    expr: &mut TExpr,
+    types: &HashMap<VariableId, Type>,
+    type_env: &HashMap<VariableId, VariableId>,
+    gen: &mut VarGen,
+) {
+    let expanded = expand_type(
+        expr.t.as_ref().expect("type inference must already be done"),
+        types,
+    );
+    expr.t = Some(expanded);
+    match &mut expr.v {
+        Expr::Sequence(exprs) => {
+            for expr in exprs {
+                expand_expr_types(expr, types, type_env, gen);
+            }
+        },
+        Expr::Infix(_, expr1, expr2) | Expr::Application(expr1, expr2) |
+        Expr::Product(expr1, expr2) => {
+            expand_expr_types(expr1, types, type_env, gen);
+            expand_expr_types(expr2, types, type_env, gen);
+        },
+        Expr::Match(matche) => {
+            expand_expr_types(&mut matche.0, types, type_env, gen);
+            for (_, expr2) in matche.1.iter_mut().zip(matche.2.iter_mut()) {
+                expand_expr_types(expr2, types, type_env, gen);
+            }
+        },
+        Expr::Negate(expr) => {
+            expand_expr_types(expr, types, type_env, gen);
+        },
+        Expr::Constant(_) | Expr::Unit | Expr::Variable(_) => {},
+        Expr::Intrinsic(Intrinsic { env, .. }) => {
+            for val in env.values_mut() {
+                expand_expr_types(val, types, type_env, gen);
+            }
+        },
+        Expr::Function(Function { body, env, .. }) => {
+            expand_expr_types(body, types, type_env, gen);
+            for val in env.values_mut() {
+                expand_expr_types(val, types, type_env, gen);
+            }
+        },
+        Expr::LetBinding(binding, expr) => {
+            expand_expr_types(&mut binding.1, types, type_env, gen);
+            expand_expr_types(expr, types, type_env, gen);
+        },
+    }
+}
+
 /* Infer the principle type of the given binding's expression and make a type
  * scheme that quantifies all free variables found in the expression that
  * cannot also be found in the environment. Finally, extend the environment with
  * the derived type schemes. */
 fn infer_binding_types(
     def: &LetBinding,
-    env: &mut Vec<Type>,
+    env_ftvs: &mut HashMap<VariableId, Variable>,
+    vars: &mut HashMap<VariableId, Type>,
     types: &mut HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
     let expr1_var = expr_type_var(&*def.1);
-    infer_expr_types(&*def.1, env, types, gen);
-    type_pattern(&def.0, expr1_var.clone(), types, gen);
-    // Collect all free variables occuring in the environment
-    let mut env_ftvs = HashMap::new();
-    for env_typ in env.iter() {
-        collect_free_type_vars(&expand_type(env_typ, types), &mut env_ftvs);
-    }
+    infer_expr_types(&*def.1, env_ftvs, vars, types, gen);
+    infer_pat_types(&def.0, vars, types, gen);
+    unify_types(pat_type_var(&def.0), expr_type_var(&def.1), types, &mut None);
     // Compute the set of free variables occuring in RHS' TYPE that
     // do not occur in the type environment
     let mut quant_vars = HashMap::new();
@@ -331,14 +358,70 @@ fn infer_binding_types(
     let mut pat_vars = HashMap::new();
     collect_pattern_variables(&def.0, &mut pat_vars);
     for pat_var in pat_vars.keys() {
-        let quant_expr = types.get_mut(&pat_var).unwrap();
+        let quant_expr = vars.get_mut(&pat_var).unwrap();
         // Quantify every free variable unique to the RHS' type
         for qvar in quant_vars.values() {
             *quant_expr = Type::Forall(qvar.clone(), Box::new(quant_expr.clone()));
         }
         // Add this type schema to the type environment in which the let
         // body is type-checked
-        env.push(quant_expr.clone());
+        let quant_expr = quant_expr.clone();
+        collect_free_type_vars(&expand_type(&quant_expr, types), env_ftvs);
+    }
+}
+
+/* Get or generate the type variable associated with a given pattern. */
+pub fn pat_type_var(pat: &TPat) -> &Type {
+    pat.t.as_ref().unwrap()
+}
+
+/* Assign each variable in the pattern an explicit type, even if that means
+ * expanding upon parts of the given type. */
+pub fn infer_pat_types(
+    pat: &TPat,
+    vars: &mut HashMap<VariableId, Type>,
+    types: &mut HashMap<VariableId, Type>,
+    gen: &mut VarGen,
+) {
+    match &pat.v {
+        Pat::Unit => {
+            let pat_var = pat_type_var(pat);
+            // (): ()
+            unify_types(pat_var, &Type::Unit, types, &mut None);
+        },
+        Pat::Constant(_) => {
+            let pat_var = pat_type_var(pat);
+            // num: int
+            unify_types(pat_var, &Type::Int, types, &mut None);
+        },
+        Pat::Variable(var) => {
+            let pat_var = pat_type_var(pat);
+            // Map the pattern name to its type
+            vars.insert(var.id, pat_var.clone());
+        },
+        Pat::As(pat1, name) => {
+            let pat1_var = pat_type_var(pat1);
+            let pat_var = pat_type_var(pat);
+            // a1: t1 |- a1 as _: t1
+            unify_types(&pat_var, &pat1_var, types, &mut None);
+            infer_pat_types(&pat1, vars, types, gen);
+            // Map the pattern name to its type
+            vars.insert(name.id, pat_var.clone());
+        },
+        Pat::Product(pat1, pat2) => {
+            let pat1_var = pat_type_var(pat1);
+            let pat2_var = pat_type_var(pat2);
+            let pat_var = pat_type_var(pat);
+            // a1: t1, a2: t2 |- (a1, a2): (t1, tN)
+            unify_types(
+                &pat_var,
+                &Type::Product(Box::new(pat1_var.clone()), Box::new(pat2_var.clone())),
+                types,
+                &mut None,
+            );
+            infer_pat_types(pat1, vars, types, gen);
+            infer_pat_types(pat2, vars, types, gen);
+        },
     }
 }
 
@@ -347,7 +430,8 @@ fn infer_binding_types(
  * context. */
 fn infer_expr_types(
     expr: &TExpr,
-    env: &Vec<Type>,
+    env: &HashMap<VariableId, Variable>,
+    vars: &HashMap<VariableId, Type>,
     types: &mut HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
@@ -355,23 +439,23 @@ fn infer_expr_types(
         Expr::Unit => {
             let expr_var = expr_type_var(expr);
             // (): ()
-            unify_types(expr_var, &Type::Unit, types);
+            unify_types(expr_var, &Type::Unit, types, &mut None);
         },
         Expr::Constant(_) => {
             let expr_var = expr_type_var(expr);
             // num: int
-            unify_types(expr_var, &Type::Int, types);
+            unify_types(expr_var, &Type::Int, types, &mut None);
         },
         Expr::Infix(InfixOp::Equal, expr1, expr2) => {
             let expr_var = expr_type_var(expr);
             let expr1_var = expr_type_var(expr1);
             let expr2_var = expr_type_var(expr2);
             // a = b: ()
-            unify_types(&expr_var, &Type::Unit, types);
+            unify_types(&expr_var, &Type::Unit, types, &mut None);
             // a: c |- b: c
-            unify_types(&expr1_var, &expr2_var, types);
-            infer_expr_types(expr1, env, types, gen);
-            infer_expr_types(expr2, env, types, gen);
+            unify_types(&expr1_var, &expr2_var, types, &mut None);
+            infer_expr_types(expr1, env, vars, types, gen);
+            infer_expr_types(expr2, env, vars, types, gen);
         },
         Expr::Infix(
             InfixOp::Add | InfixOp::Subtract | InfixOp::Multiply |
@@ -384,31 +468,31 @@ fn infer_expr_types(
             let expr1_var = expr_type_var(expr1);
             let expr2_var = expr_type_var(expr2);
             // a op b: int
-            unify_types(&expr_var, &Type::Int, types);
+            unify_types(&expr_var, &Type::Int, types, &mut None);
             // a: int
-            unify_types(&expr1_var, &Type::Int, types);
+            unify_types(&expr1_var, &Type::Int, types, &mut None);
             // b: int
-            unify_types(&expr2_var, &Type::Int, types);
-            infer_expr_types(expr1, env, types, gen);
-            infer_expr_types(expr2, env, types, gen);
+            unify_types(&expr2_var, &Type::Int, types, &mut None);
+            infer_expr_types(expr1, env, vars, types, gen);
+            infer_expr_types(expr2, env, vars, types, gen);
         },
         Expr::Negate(expr1) => {
             let expr_var = expr_type_var(expr);
             let expr1_var = expr_type_var(expr1);
             // (-a): int
-            unify_types(&expr_var, &Type::Int, types);
+            unify_types(&expr_var, &Type::Int, types, &mut None);
             // a: int
-            unify_types(&expr1_var, &Type::Int, types);
-            infer_expr_types(expr1, env, types, gen);
+            unify_types(&expr1_var, &Type::Int, types, &mut None);
+            infer_expr_types(expr1, env, vars, types, gen);
         },
         Expr::Sequence(seq) => {
             let last_expr = seq.last().expect("encountered empty sequence");
             let expr_var = expr_type_var(expr);
             let last_expr_var = expr_type_var(last_expr);
             // aN: c |- (a1; ...; aN): c
-            unify_types(&expr_var, &last_expr_var, types);
+            unify_types(&expr_var, &last_expr_var, types, &mut None);
             for expr in seq {
-                infer_expr_types(expr, env, types, gen);
+                infer_expr_types(expr, env, vars, types, gen);
             }
         },
         Expr::Product(expr1, expr2) => {
@@ -419,10 +503,11 @@ fn infer_expr_types(
             unify_types(
                 &expr_var,
                 &Type::Product(Box::new(expr1_var.clone()), Box::new(expr2_var.clone())),
-                types
+                types,
+                &mut None,
             );
-            infer_expr_types(expr1, env, types, gen);
-            infer_expr_types(expr2, env, types, gen);
+            infer_expr_types(expr1, env, vars, types, gen);
+            infer_expr_types(expr2, env, vars, types, gen);
         },
         Expr::Application(expr1, expr2) => {
             let expr_var = expr_type_var(expr);
@@ -435,69 +520,74 @@ fn infer_expr_types(
                     Box::new(expr2_var.clone()),
                     Box::new(expr_var.clone())
                 ),
-                types
+                types,
+                &mut None
             );
-            infer_expr_types(expr1, env, types, gen);
-            infer_expr_types(expr2, env, types, gen);
+            infer_expr_types(expr1, env, vars, types, gen);
+            infer_expr_types(expr2, env, vars, types, gen);
         },
-        Expr::Function(Function(params, expr1)) => {
+        Expr::Function(Function { params, body: expr1, .. }) => {
             let expr_var = expr_type_var(expr);
             let expr1_var = expr_type_var(expr1);
             let mut func_var = expr1_var.clone();
             let mut env = env.clone();
+            let mut vars = vars.clone();
             for param in params.iter().rev() {
-                let param_var = pattern_type(param);
-                env.push(param_var.clone());
-                func_var = Type::Function(Box::new(param_var), Box::new(func_var));
+                infer_pat_types(param, &mut vars, types, gen);
+                let param_type = pat_type_var(param);
+                collect_free_type_vars(&expand_type(&param_type, types), &mut env);
+                func_var = Type::Function(Box::new(param_type.clone()), Box::new(func_var));
             }
             // a1: t1, ..., aN: tN |- b: u
             // fun a1 ... aN -> b : t1 -> ... -> tN -> u
-            unify_types(&expr_var, &func_var, types);
-            infer_expr_types(expr1, &env, types, gen);
+            unify_types(&expr_var, &func_var, types, &mut None);
+            infer_expr_types(expr1, &env, &vars, types, gen);
         },
         Expr::Match(matche) => {
             let expr_var = expr_type_var(expr);
             let expr1_var = expr_type_var(&matche.0);
             for (pat, expr2) in matche.1.iter().zip(matche.2.iter()) {
-                let pat_var = pattern_type(pat);
-                unify_types(&pat_var, &expr1_var, types);
+                let mut vars = vars.clone();
+                let mut env = env.clone();
+                infer_pat_types(pat, &mut vars, types, gen);
+                let pat_type = pat_type_var(pat);
+                unify_types(&pat_type, &expr1_var, types, &mut None);
                 let expr2_var = expr_type_var(expr2);
-                unify_types(&expr_var, &expr2_var, types);
-            }
-            for expr2 in matche.2.iter() {
-                infer_expr_types(expr2, &env, types, gen);
+                unify_types(&expr_var, &expr2_var, types, &mut None);
+                collect_free_type_vars(&expand_type(&pat_type, types), &mut env);
+                infer_expr_types(expr2, &env, &vars, types, gen);
             }
         },
-        Expr::Intrinsic(Intrinsic { args, imp_typ, ..}) => {
+        Expr::Intrinsic(Intrinsic { params, ..}) => {
             let expr_var = expr_type_var(expr);
-            let mut func_var = expr_var.clone();
-            for arg in args.iter().rev() {
-                let arg_var = expr_type_var(arg);
-                func_var = Type::Function(Box::new(arg_var.clone()), Box::new(func_var));
+            let mut vars = vars.clone();
+            let mut func_var = Type::Variable(Variable::new(gen.generate_id()));
+            for param in params.iter().rev() {
+                infer_pat_types(param, &mut vars, types, gen);
+                let param_type = pat_type_var(param);
+                func_var = Type::Function(Box::new(param_type.clone()), Box::new(func_var));
             }
-            // b: t, a b: u |- a: t -> u
-            unify_types(&func_var, &imp_typ, types);
-            for arg in args {
-                infer_expr_types(arg, &env, types, gen);
-            }
+            unify_types(&func_var, &expr_var, types, &mut None);
         },
         Expr::LetBinding(def, expr2) => {
             let expr_var = expr_type_var(expr);
             let expr2_var = expr_type_var(expr2);
             let mut env = env.clone();
-            infer_binding_types(def, &mut env, types, gen);
-            unify_types(&expr_var, &expr2_var, types);
-            infer_expr_types(expr2, &env, types, gen);
+            let mut vars = vars.clone();
+            infer_binding_types(def, &mut env, &mut vars, types, gen);
+            unify_types(&expr_var, &expr2_var, types, &mut None);
+            infer_expr_types(expr2, &env, &vars, types, gen);
         },
         Expr::Variable(var) => {
             let expr_var = expr_type_var(expr);
-            let mut fresh = expand_type(&Type::Variable(var.clone()), types);
+            let mut fresh = expand_type(&vars[&var.id], types);
             let mut new_map = HashMap::new();
             instantiate_type_vars(&mut fresh, &mut new_map, gen);
             unify_types(
                 &expr_var,
                 &fresh,
-                types
+                types,
+                &mut None,
             );
         },
     }
@@ -507,110 +597,116 @@ fn infer_expr_types(
  */
 fn infer_def_types(
     def: &Definition,
-    env: &mut Vec<Type>,
+    env: &mut HashMap<VariableId, Variable>,
+    vars: &mut HashMap<VariableId, Type>,
     types: &mut HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
-    infer_binding_types(&def.0, env, types, gen);
+    infer_binding_types(&def.0, env, vars, types, gen);
 }
 
 /* Type check the module using Hindley Milner. */
 pub fn infer_module_types(
     annotated: &mut Module,
     globals: &HashMap<String, VariableId>,
+    vars: &mut HashMap<VariableId, Type>,
     types: &mut HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
     allocate_module_types(annotated, gen);
-    let mut env = Vec::new();
+    let mut env = HashMap::new();
     // Initialize the type environment with the types of global variables
     for (name, id) in globals {
-        let mut var = Variable::new(*id);
-        var.name = Some(name.clone());
-        env.push(Type::Variable(var));
+        if !vars.contains_key(id) {
+            let mut var = Variable::new(gen.generate_id());
+            var.name = Some(name.clone());
+            vars.insert(*id, Type::Variable(var));
+        }
+    }
+    for typ in vars.values() {
+        collect_free_type_vars(typ, &mut env);
     }
     for def in &mut annotated.defs {
-        infer_def_types(def, &mut env, types, gen);
+        infer_def_types(def, &mut env, vars, types, gen);
     }
     for expr in &mut annotated.exprs {
-        infer_expr_types(expr, &env, types, gen);
+        infer_expr_types(expr, &env, vars, types, gen);
     }
 }
 
 /* Expand tuple pattern variables into tuple patterns. */
-fn expand_pattern_variables(
-    pat: &mut Pattern,
-    typ: &Type,
-    map: &mut HashMap<VariableId, Pattern>,
+pub fn expand_pattern_variables(
+    pat: &mut TPat,
+    map: &mut HashMap<VariableId, TPat>,
+    types: &HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
-    match (&mut *pat, typ) {
-        (Pattern::Variable(var), _) if map.contains_key(&var.id) => {
+    let typ = partial_expand_type(pat_type_var(pat), types);
+    match (&mut pat.v, typ) {
+        (Pat::Variable(var), _) if map.contains_key(&var.id) => {
             *pat = map[&var.id].clone();
         },
-        (Pattern::Variable(var), Type::Product(typ1, typ2)) => {
+        (Pat::Variable(var), Type::Product(typ1, typ2)) => {
             let mut new_var1 = Variable::new(gen.generate_id());
             new_var1.name = var
                 .name
                 .as_ref()
                 .map(|x| x.to_owned() + ".0");
-            let mut var1 = Pattern::Variable(new_var1);
-            expand_pattern_variables(&mut var1, typ1, map, gen);
+            let mut var1 = Pat::Variable(new_var1).type_pat(Some(*typ1.clone()));
+            expand_pattern_variables(&mut var1, map, types, gen);
             
             let mut new_var2 = Variable::new(gen.generate_id());
             new_var2.name = var
                 .name
                 .as_ref()
                 .map(|x| x.to_owned() + ".1");
-            let mut var2 = Pattern::Variable(new_var2);
-            expand_pattern_variables(&mut var2, typ2, map, gen);
-            
-            let new_pat = Pattern::Product(Box::new(var1), Box::new(var2));
-            map.insert(var.id, new_pat.clone());
-            *pat = new_pat;
+            let mut var2 = Pat::Variable(new_var2).type_pat(Some(*typ2.clone()));
+            expand_pattern_variables(&mut var2, map, types, gen);
+
+            let curr_id = var.id;
+            pat.v = Pat::Product(Box::new(var1), Box::new(var2));
+            map.insert(curr_id, pat.clone());
         },
-        (Pattern::Variable(var), Type::Unit) => {
-            map.insert(var.id, Pattern::Unit);
-            *pat = Pattern::Unit;
+        (Pat::Variable(var), Type::Unit) => {
+            map.insert(var.id, Pat::Unit.type_pat(Some(Type::Unit)));
+            *pat = map[&var.id].clone();
         },
-        (Pattern::Variable(_), _) => {},
-        (Pattern::Product(pat1, pat2), Type::Product(typ1, typ2)) => {
-            expand_pattern_variables(pat1, typ1, map, gen);
-            expand_pattern_variables(pat2, typ2, map, gen);
+        (Pat::Variable(_), _) => {},
+        (Pat::Product(pat1, pat2), _) => {
+            expand_pattern_variables(pat1, map, types, gen);
+            expand_pattern_variables(pat2, map, types, gen);
         },
-        (Pattern::Constant(_), Type::Int) => {},
-        (Pattern::Unit, Type::Unit) => {},
-        (Pattern::As(_pat, _name), typ) => {
-            expand_pattern_variables(pat, typ, map, gen);
+        (Pat::Constant(_), Type::Int) => {},
+        (Pat::Unit, Type::Unit) => {},
+        (Pat::As(pat1, _name), _) => {
+            expand_pattern_variables(pat1, map, types, gen);
         },
-        _ => panic!("pattern {} cannot have type {}", pat, typ),
+        _ => panic!("pattern {} cannot have type {}", pat, pat_type_var(pat)),
     }
 }
 
 /* Expand tuple expression variables into tuple expressions. */
-fn expand_variables(
+pub fn expand_variables(
     expr: &mut TExpr,
-    map: &mut HashMap<VariableId, Pattern>,
+    map: &mut HashMap<VariableId, TPat>,
     types: &HashMap<VariableId, Type>,
     gen: &mut VarGen,
 ) {
     match &mut expr.v {
         Expr::LetBinding(binding, body) => {
             expand_variables(&mut *binding.1, map, types, gen);
-            let typ = expand_type(binding.1.t.as_ref().unwrap(), types);
-            expand_pattern_variables(&mut binding.0, &typ, map, gen);
+            expand_pattern_variables(&mut binding.0, map, types, gen);
             expand_variables(body, map, types, gen);
         },
-        Expr::Sequence(exprs) | Expr::Intrinsic(Intrinsic { args: exprs, .. }) => {
+        Expr::Sequence(exprs) => {
             for expr in exprs {
                 expand_variables(expr, map, types, gen);
             }
         },
         Expr::Match(matche) => {
             expand_variables(&mut matche.0, map, types, gen);
-            let pat_typ = expand_type(matche.0.t.as_ref().unwrap(), types);
             for (pat, expr2) in matche.1.iter_mut().zip(matche.2.iter_mut()) {
-                expand_pattern_variables(pat, &pat_typ, map, gen);
+                expand_pattern_variables(pat, map, types, gen);
                 expand_variables(expr2, map, types, gen);
             }
         },
@@ -623,130 +719,93 @@ fn expand_variables(
             expand_variables(expr1, map, types, gen);
         },
         Expr::Variable(var) if map.contains_key(&var.id) => {
-            let typ = expand_type(expr.t.as_ref().unwrap(), types);
-            *expr = map[&var.id].to_typed_expr(typ);
+            *expr = map[&var.id].to_expr();
         },
         Expr::Variable(var) if expr.t.is_some() => {
-            let expanded_type = expand_type(expr.t.as_ref().unwrap(), types);
+            let expanded_type = partial_expand_type(expr.t.as_ref().unwrap(), types);
             if let Type::Product(typ1, typ2) = expanded_type {
                 let mut new_var1 = Variable::new(gen.generate_id());
                 new_var1.name = var
                     .name
                     .as_ref()
                     .map(|x| x.to_owned() + ".0");
-                let var_pat1 = Pattern::Variable(new_var1);
-                let mut var_expr1 = var_pat1.to_typed_expr(*typ1);
-                expand_variables(&mut var_expr1, map, types, gen);
+                let var_expr1 = Expr::Variable(new_var1.clone()).type_expr(Some(*typ1.clone()));
                 
                 let mut new_var2 = Variable::new(gen.generate_id());
                 new_var2.name = var
                     .name
                     .as_ref()
                     .map(|x| x.to_owned() + ".1");
-                let var_pat2 = Pattern::Variable(new_var2);
-                let mut var_expr2 = var_pat2.to_typed_expr(*typ2);
-                expand_variables(&mut var_expr2, map, types, gen);
+                let var_expr2 = Expr::Variable(new_var2.clone()).type_expr(Some(*typ2.clone()));
                 
-                map.insert(var.id, Pattern::Product(
-                    Box::new(var_pat1),
-                    Box::new(var_pat2),
-                ));
+                map.insert(var.id, Pat::Product(
+                    Box::new(Pat::Variable(new_var1).type_pat(Some(*typ1.clone()))),
+                    Box::new(Pat::Variable(new_var2).type_pat(Some(*typ2.clone()))),
+                ).type_pat(expr.t.clone()));
                 *expr = TExpr {
                     v: Expr::Product(Box::new(var_expr1), Box::new(var_expr2)),
                     t: expr.t.clone(),
                 };
+                expand_variables(&mut *expr, map, types, gen);
             } else if let Type::Unit = expanded_type {
-                map.insert(var.id, Pattern::Unit);
+                map.insert(var.id, Pat::Unit.type_pat(Some(Type::Unit)));
                 *expr = TExpr { v: Expr::Unit, t: expr.t.clone() };
             }
         },
         Expr::Function(fun) => {
-            expand_variables(&mut fun.1, map, types, gen);
+            expand_variables(&mut fun.body, map, types, gen);
         },
-        Expr::Constant(_) | Expr::Variable(_) | Expr::Unit => {},
+        Expr::Constant(_) | Expr::Variable(_) | Expr::Unit |
+        Expr::Intrinsic(_) => {},
     }
 }
 
-/* Expand tuple variables occuring in given definition into tuples. */
-fn expand_def_variables(
-    def: &mut Definition,
-    map: &mut HashMap<VariableId, Pattern>,
-    types: &mut HashMap<VariableId, Type>,
-    gen: &mut VarGen,
-) {
-    expand_variables(&mut *def.0.1, map, types, gen);
-    let typ = expand_type(def.0.1.t.as_ref().unwrap(), types);
-    expand_pattern_variables(&mut def.0.0, &typ, map, gen);
-}
-
-/* Expand tuple variables occuring in given module into tuples. */
-pub fn expand_module_variables(
-    module: &mut Module,
-    types: &mut HashMap<VariableId, Type>,
-    gen: &mut VarGen,
-) {
-    let mut pattern_map = HashMap::new();
-    for def in &mut module.defs {
-        expand_def_variables(def, &mut pattern_map, types, gen);
-    }
-    for expr in &mut module.exprs {
-        expand_variables(expr, &mut pattern_map, types, gen);
-    }
-}
-
-/* Returns the given type with all function inner types are replaced by units.
+/* Replace all the function types occurring in this type expression with units.
  */
 fn unitize_type_functions(
-    typ: Type,
+    typ: &mut Type,
     types: &mut HashMap<VariableId, Type>,
-) -> Type {
-    match &typ {
+) {
+    match typ {
         Type::Variable(var) if types.contains_key(&var.id) => {
-            let res = unitize_type_functions(types[&var.id].clone(), types);
-            types.insert(var.id, res);
-            typ
+            // Temporarily checkout the current type expression to avoid having
+            // multiple borrows.
+            let mut curr = types.remove(&var.id).unwrap();
+            unitize_type_functions(&mut curr, types);
+            types.insert(var.id, curr);
         }
-        Type::Variable(_) | Type::Int | Type::Unit => typ,
-        Type::Function(_, _) => Type::Unit,
+        Type::Variable(_) | Type::Int | Type::Unit => {},
+        Type::Function(_, _) => *typ = Type::Unit,
         Type::Product(typ1, typ2) => {
-            Type::Product(
-                Box::new(unitize_type_functions(*typ1.clone(), types)),
-                Box::new(unitize_type_functions(*typ2.clone(), types)),
-            )
+            unitize_type_functions(&mut *typ1, types);
+            unitize_type_functions(&mut *typ2, types);
         },
-        Type::Forall(var, b) => Type::Forall(
-            var.clone(),
-            Box::new(unitize_type_functions(*b.clone(), types)),
-        ),
+        Type::Forall(_, b) => unitize_type_functions(b, types),
     }
 }
 
 /* Takes a pattern and its type. Returns a pattern where pattern variables
  * corresponding to function types are replaced by units. */
 fn unitize_pattern_functions(
-    pat: Pattern,
-    typ: &Type,
+    pat: &mut TPat,
     types: &HashMap<VariableId, Type>,
-) -> Pattern {
-    match (pat, typ) {
-        (pat, Type::Variable(var)) if types.contains_key(&var.id) => {
-            unitize_pattern_functions(pat, &types[&var.id], types)
+) {
+    let typ = partial_expand_type(pat_type_var(&pat), types);
+    match (&mut pat.v, typ) {
+        (Pat::Variable(_), Type::Function(_, _)) => {
+            *pat = Pat::Unit.type_pat(Some(Type::Unit));
         },
-        (Pattern::Variable(_), Type::Function(_, _)) => Pattern::Unit,
-        (Pattern::As(inner_pat, name), _) => {
-            let inner_pat = unitize_pattern_functions(*inner_pat, typ, types);
-            Pattern::As(Box::new(inner_pat), name.clone())
+        (Pat::As(inner_pat, _), _) => {
+            unitize_pattern_functions(inner_pat, types);
         },
-        (Pattern::Product(pat1, pat2), Type::Product(typ1, typ2)) => {
-            Pattern::Product(
-                Box::new(unitize_pattern_functions(*pat1, typ1, types)),
-                Box::new(unitize_pattern_functions(*pat2, typ2, types)),
-            )
+        (Pat::Product(pat1, pat2), _) => {
+            unitize_pattern_functions(pat1, types);
+            unitize_pattern_functions(pat2, types);
         },
-        (pat @ Pattern::Variable(_), Type::Variable(_)) => pat,
-        (pat @ (Pattern::Constant(_) | Pattern::Variable(_)), Type::Int) => pat,
-        (pat @ (Pattern::Unit | Pattern::Variable(_)), Type::Unit) => pat,
-        (pat, typ) =>
+        (Pat::Variable(_), Type::Variable(_)) => {},
+        (Pat::Constant(_) | Pat::Variable(_), Type::Int) => {},
+        (Pat::Unit | Pat::Variable(_), Type::Unit) => {},
+        (_, typ) =>
             panic!("pattern {} does not correspond to type {}", pat, typ),
     }
 }
@@ -767,9 +826,8 @@ fn unitize_expr_functions(
         },
         Expr::Match(matche) => {
             unitize_expr_functions(&mut matche.0, types);
-            let pat_type = matche.0.t.as_ref().unwrap();
             for (pat, expr2) in matche.1.iter_mut().zip(matche.2.iter_mut()) {
-                *pat = unitize_pattern_functions(pat.clone(), pat_type, types);
+                unitize_pattern_functions(pat, types);
                 unitize_expr_functions(expr2, types);
             }
         },
@@ -779,8 +837,7 @@ fn unitize_expr_functions(
             unitize_expr_functions(expr2, types);
         },
         Expr::LetBinding(binding, body) => {
-            let binding_type = binding.1.t.as_ref().unwrap();
-            binding.0 = unitize_pattern_functions(binding.0.clone(), binding_type, types);
+            unitize_pattern_functions(&mut binding.0, types);
             unitize_expr_functions(&mut *binding.1, types);
             unitize_expr_functions(body, types);
         },
@@ -794,7 +851,7 @@ fn unitize_expr_functions(
         },
     }
     // Scrub functions from this expression's type
-    expr.t = expr.t.clone().map(|x| unitize_type_functions(x, types));
+    unitize_type_functions(expr.t.as_mut().unwrap(), types);
 }
 
 /* Replace all functions occuring in the given definition with 0-tuples. */
@@ -802,8 +859,7 @@ fn unitize_def_functions(
     def: &mut Definition,
     types: &mut HashMap<VariableId, Type>,
 ) {
-    let binding_type = def.0.1.t.as_ref().unwrap();
-    def.0.0 = unitize_pattern_functions(def.0.0.clone(), binding_type, types);
+    unitize_pattern_functions(&mut def.0.0, types);
     unitize_expr_functions(&mut *def.0.1, types);
 }
 

--- a/src/vampir.pest
+++ b/src/vampir.pest
@@ -10,7 +10,13 @@ valueName = { !keyword ~ ident }
 
 infixOp = { "/" | "*" | "+" | "-" | "=" | "^" | "\\" | "%" }
 
-integerLiteral = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+binary = @{ '0'..'1' }
+
+octal = @{ '0'..'7' }
+
+hexadecimal = @{ '0'..'9' | 'a'..'f' | 'A'..'F' }
+
+integerLiteral = @{ "0x" ~ hexadecimal+ | "0o" ~ octal+ | "0b" ~ binary+ | ASCII_DIGIT+ }
 
 constant = { integerLiteral | "(" ~ ")" }
 

--- a/tests/blake2s.pir
+++ b/tests/blake2s.pir
@@ -1,0 +1,233 @@
+/* An implementation of standard arithmetic logic unit operations in vampir. Run
+   as follows:
+   vamp-ir setup params.pp
+   vamp-ir compile tests/alu.pir params.pp circuit.plonk
+   vamp-ir prove circuit.plonk params.pp proof.plonk
+   vamp-ir verify circuit.plonk params.pp proof.plonk
+*/
+
+// Ensure that the given argument is 1 or 0, and returns it
+def bool x = { x*(x-1) = 0; x };
+
+// Extract the 32 bits from a number argument
+def range32 a = {
+    def a0 = bool (fresh ((a\1) % 2));
+    def a1 = bool (fresh ((a\2) % 2));
+    def a2 = bool (fresh ((a\4) % 2));
+    def a3 = bool (fresh ((a\8) % 2));
+    def a4 = bool (fresh ((a\16) % 2));
+    def a5 = bool (fresh ((a\32) % 2));
+    def a6 = bool (fresh ((a\64) % 2));
+    def a7 = bool (fresh ((a\128) % 2));
+    def a8 = bool (fresh ((a\256) % 2));
+    def a9 = bool (fresh ((a\512) % 2));
+    def a10 = bool (fresh ((a\1024) % 2));
+    def a11 = bool (fresh ((a\2048) % 2));
+    def a12 = bool (fresh ((a\4096) % 2));
+    def a13 = bool (fresh ((a\8192) % 2));
+    def a14 = bool (fresh ((a\16384) % 2));
+    def a15 = bool (fresh ((a\32768) % 2));
+    def a16 = bool (fresh ((a\65536) % 2));
+    def a17 = bool (fresh ((a\131072) % 2));
+    def a18 = bool (fresh ((a\262144) % 2));
+    def a19 = bool (fresh ((a\524288) % 2));
+    def a20 = bool (fresh ((a\1048576) % 2));
+    def a21 = bool (fresh ((a\2097152) % 2));
+    def a22 = bool (fresh ((a\4194304) % 2));
+    def a23 = bool (fresh ((a\8388608) % 2));
+    def a24 = bool (fresh ((a\16777216) % 2));
+    def a25 = bool (fresh ((a\33554432) % 2));
+    def a26 = bool (fresh ((a\67108864) % 2));
+    def a27 = bool (fresh ((a\134217728) % 2));
+    def a28 = bool (fresh ((a\268435456) % 2));
+    def a29 = bool (fresh ((a\536870912) % 2));
+    def a30 = bool (fresh ((a\1073741824) % 2));
+    def a31 = bool (fresh ((a\2147483648) % 2));
+    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7 + 256*a8 + 512*a9 + 1024*a10 + 2048*a11 + 4096*a12 + 8192*a13 + 16384*a14 + 32768*a15 + 65536*a16 + 131072*a17 + 262144*a18 + 524288*a19 + 1048576*a20 + 2097152*a21 + 4194304*a22 + 8388608*a23 + 16777216*a24 + 33554432*a25 + 67108864*a26 + 134217728*a27 + 268435456*a28 + 536870912*a29 + 1073741824*a30 + 2147483648*a31;
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, ())
+};
+
+// Pair up corresponding elements of each tuple
+def zip32 (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,ar) (b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,br) = {
+    ((a0,b0),(a1,b1),(a2,b2),(a3,b3),(a4,b4),(a5,b5),(a6,b6),(a7,b7),(a8,b8),(a9,b9),(a10,b10),(a11,b11),(a12,b12),(a13,b13),(a14,b14),(a15,b15),(a16,b16),(a17,b17),(a18,b18),(a19,b19),(a20,b20),(a21,b21),(a22,b22),(a23,b23),(a24,b24),(a25,b25),(a26,b26),(a27,b27),(a28,b28),(a29,b29),(a30,b30),(a31,b31),())
+};
+// Apply function to each element of tuple
+def map f (g0,g1,g2,g3,g4,g5,g6,g7,g8,g9,g10,g11,g12,g13,g14,g15,g16,g17,g18,g19,g20,g21,g22,g23,g24,g25,g26,g27,g28,g29,g30,g31,gr) = {
+    (f g0, f g1, f g2, f g3, f g4, f g5, f g6, f g7, f g8, f g9, f g10, f g11, f g12, f g13, f g14, f g15, f g16, f g17, f g18, f g19, f g20, f g21, f g22, f g23, f g24, f g25, f g26, f g27, f g28, f g29, f g30, f g31, ())
+};
+
+// Multiply each tuple element by corresponding unit
+def combine32 (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31, ar) = {
+    a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4 + 32*a5 + 64*a6 + 128*a7 + 256*a8 + 512*a9 + 1024*a10 + 2048*a11 + 4096*a12 + 8192*a13 + 16384*a14 + 32768*a15 + 65536*a16 + 131072*a17 + 262144*a18 + 524288*a19 + 1048576*a20 + 2097152*a21 + 4194304*a22 + 8388608*a23 + 16777216*a24 + 33554432*a25 + 67108864*a26 + 134217728*a27 + 268435456*a28 + 536870912*a29 + 1073741824*a30 + 2147483648*a31
+};
+def combine32_little (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31, ar) = {
+    a31 + 2*a30 + 4*a29 + 8*a28 + 16*a27 + 32*a26 + 64*a25 + 128*a24 + 256*a23 + 512*a22 + 1024*a21 + 2048*a20 + 4096*a19 + 8192*a18 + 16384*a17 + 32768*a16 + 65536*a15 + 131072*a14 + 262144*a13 + 524288*a12 + 1048576*a11 + 2097152*a10 + 4194304*a9 + 8388608*a8 + 16777216*a7 + 33554432*a6 + 67108864*a5 + 134217728*a4 + 268435456*a3 + 536870912*a2 + 1073741824*a1 + 2147483648*a0
+};
+
+// Apply given function to corresponding bit-pairs in bit representation
+def bitwise32 g a b = {
+    def zipped = zip32 (range32 a) (range32 b);
+    def new_bits = map g zipped;
+    combine32 new_bits
+};
+
+// Definition of xor for domain {0, 1}^2
+def bit_xor (a,b) = { a*(1-b)+(1-a)*b };
+
+// Definition of bitwise xor for 32 bit values
+def xor32 = bitwise32 bit_xor;
+
+// BLAKE 2 rotations
+def r1 x = {
+    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,ar) = range32 x;
+    combine32 (a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, ())
+    };
+def r2 x = {
+    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,ar) = range32 x;
+    combine32 (a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, ())
+    };
+def r3 x = {
+    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,ar) = range32 x;
+    combine32 (a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a0, a1, a2, a3, a4, a5, a6, a7, ())
+};
+def r4 x = {
+    def (a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,ar) = range32 x;
+    combine32 (a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a0, a1, a2, a3, a4, a5, a6, ())
+};
+
+// BLAKE 2 mixer function
+def g_mixer (va,vb,vc,vd,x,y) = {
+    def va1 = fresh((va + vb + x) % 4294967296);
+    def vd1 = r1 (xor32 vd va1);
+    def vc1 = fresh((vc + vd1) % 4294967296);
+    def vb1 = r2 (xor32 vb vc1);
+    def va2 = fresh((va1 + vb1 + y) % 4294967296);
+    def vd2 = r3 (xor32 vd1 va2);
+    def vc2 = fresh((vc1 + vd2) % 4294967296);
+    def vb2 = r4 (xor32 vb1 vc2);
+    (va2, vb2, vc2, vd2)
+};
+
+// BLAKE 2
+
+// !! INPUT MESSAGE !!
+def (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) = (6513249, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+// IV = (1779033703, 3144134277 , 1013904242, 2773480762, 1359893119, 2600822924, 528734635, 1541459225);
+// // Parameter block p[0]
+// h[0] := h[0] ^ 0x01010000 ^ (kk << 8) ^ nn
+//
+// 0x01010000 = 16842752
+// kk = 'secret key' = 0
+// In id-blake2s256 nn = 32
+// 1779033703 ^ 16842752 ^ (0 << 8)= 1795745383
+
+// First H vector, is equal to the IV
+def (h0, h1, h2, h3, h4, h5, h6, h7) = (1779033703, 3144134277 , 1013904242, 2773480762, 1359893119, 2600822924, 528734635, 1541459225);
+
+// Second H vector has first value modified
+def h0 = xor32 (xor32 h0 16842752) 32;
+
+def (h0_0, h1_0, h2_0, h3_0, h4_0, h5_0, h6_0, h7_0) = (h0, 3144134277 , 1013904242, 2773480762, 1359893119, 2600822924, 528734635, 1541459225);
+
+// In our scenario, dd = 1. So we go straight to the final block:
+// h := F( h, d[dd - 1], ll + bb, TRUE ) = F(h, m, ll, TRUE)
+// h is the one from above.
+// len(d) = 1, d[0] = (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15)
+// ll: Input bytes; bb: block bytes.
+// ll = 3; bb = 64
+
+def ll = 3;
+
+// ################ F ################ //
+
+// Inizialize working vector v, first half from the state h, second half from IV.
+
+def (v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15) = (h0_0, h1_0, h2_0, h3_0, h4_0, h5_0, h6_0, h7_0, 1779033703, 3144134277 , 1013904242, 2773480762, 1359893119, 2600822924, 528734635, 1541459225);
+def v12 = xor32 v12 (fresh(ll % 4294967296));
+def v14 = xor32 v14 4294967295;
+def (v0_0,v1_0,v2_0,v3_0,v4_0,v5_0,v6_0,v7_0,v8_0,v9_0,v10_0,v11_0,v12_0,v13_0,v14_0,v15_0) = (v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15);
+// first check with reference
+// (v0_0,v1_0,v2_0,v3_0,v4_0,v5_0,v6_0,v7_0,v8_0,v9_0,v10_0,v11_0,v12_0,v13_0,v14_0,v15_0) = (1795745351,3144134277,1013904242,2773480762,1359893119,2600822924,528734635,1541459225,1779033703,3144134277,1013904242,2773480762,1359893116,2600822924,3766232660,1541459225);
+
+// mixer functions aggregation function. First act on the columns then on the diagnoals of the 4x4 v_ij matrix
+def g_total (v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15) (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = {
+    // Columns
+    def (v0_1, v4_1, v8_1, v12_1) = g_mixer(v0, v4, v8, v12, m0, m1);
+    def (v1_1, v5_1, v9_1, v13_1) = g_mixer(v1, v5, v9, v13, m2, m3);
+    def (v2_1, v6_1, v10_1, v14_1) = g_mixer(v2, v6, v10, v14, m4, m5);
+    def (v3_1, v7_1, v11_1, v15_1) = g_mixer(v3, v7, v11, v15, m6, m7);
+
+    // Diagonals
+    def (v0_2, v5_2, v10_2, v15_2) = g_mixer(v0_1, v5_1, v10_1, v15_1, m8, m9);
+    def (v1_2, v6_2, v11_2, v12_2) = g_mixer(v1_1, v6_1, v11_1, v12_1, m10, m11);
+    def (v2_2, v7_2, v8_2, v13_2) = g_mixer(v2_1, v7_1, v8_1, v13_1, m12, m13);
+    def (v3_2, v4_2, v9_2, v14_2) = g_mixer(v3_1, v4_1, v9_1, v14_1, m14, m15);
+
+    (v0_2, v1_2, v2_2, v3_2, v4_2, v5_2, v6_2, v7_2, v8_2, v9_2, v10_2, v11_2, v12_2, v13_2, v14_2, v15_2)
+};
+
+// Sigma permutations from reference
+def sigma0 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15)};
+def sigma1 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s14, s10, s4, s8, s9, s15, s13, s6, s1, s12, s0, s2, s11, s7, s5, s3)};
+def sigma2 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s11, s8, s12, s0, s5, s2, s15, s13, s10, s14, s3, s6, s7, s1, s9, s4)};
+def sigma3 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s7, s9, s3, s1, s13, s12, s11, s14, s2, s6, s5, s10, s4, s0, s15, s8)};
+def sigma4 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s9, s0, s5, s7, s2, s4, s10, s15, s14, s1, s11, s12, s6, s8, s3, s13)};
+def sigma5 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s2, s12, s6, s10, s0, s11, s8, s3, s4, s13, s7, s5, s15, s14, s1, s9)};
+def sigma6 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s12, s5, s1, s15, s14, s13, s4, s10, s0, s7, s6, s3, s9, s2, s8, s11)};
+def sigma7 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s13, s11, s7, s14, s12, s1, s3, s9, s5, s0, s15, s4, s8, s6, s2, s10)};
+def sigma8 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s6, s15, s14, s9, s11, s3, s0, s8, s12, s2, s13, s7, s1, s4, s10, s5)};
+def sigma9 (s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15) = {(s10, s2, s8, s4, s7, s6, s1, s5, s15, s11, s9, s14, s3, s12, s13, s0)};
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma0  (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_1,v1_1,v2_1,v3_1,v4_1,v5_1,v6_1,v7_1,v8_1,v9_1,v10_1,v11_1,v12_1,v13_1,v14_1,v15_1) = g_total (v0_0,v1_0,v2_0,v3_0,v4_0,v5_0,v6_0,v7_0,v8_0,v9_0,v10_0,v11_0,v12_0,v13_0,v14_0,v15_0)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+// check from reference:
+// (v0_1,v1_1,v2_1,v3_1,v4_1,v5_1,v6_1,v7_1,v8_1,v9_1,v10_1,v11_1,v12_1,v13_1,v14_1,v15_1) = (379790382,3619021368,3465339467,2457529825,2813604057,2477039950,2756607025,1104442779,2512335827,2593767809,1619671659,3060152382,2056115471,3191312087,893198054,1001671787);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma1 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_2,v1_2,v2_2,v3_2,v4_2,v5_2,v6_2,v7_2,v8_2,v9_2,v10_2,v11_2,v12_2,v13_2,v14_2,v15_2) = g_total (v0_1,v1_1,v2_1,v3_1,v4_1,v5_1,v6_1,v7_1,v8_1,v9_1,v10_1,v11_1,v12_1,v13_1,v14_1,v15_1)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+// check from reference:
+// (v0_2,v1_2,v2_2,v3_2,v4_2,v5_2,v6_2,v7_2,v8_2,v9_2,v10_2,v11_2,v12_2,v13_2,v14_2,v15_2) = (987959267,159557995,3900802484,1043569430,4064491725,241619750,3758484748,3583091319,403382074,4243863828,819684054,1212646172,2130757006,4219762822,3309627446,1380626658);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma2 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_3,v1_3,v2_3,v3_3,v4_3,v5_3,v6_3,v7_3,v8_3,v9_3,v10_3,v11_3,v12_3,v13_3,v14_3,v15_3) = g_total (v0_2,v1_2,v2_2,v3_2,v4_2,v5_2,v6_2,v7_2,v8_2,v9_2,v10_2,v11_2,v12_2,v13_2,v14_2,v15_2)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma3 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_4,v1_4,v2_4,v3_4,v4_4,v5_4,v6_4,v7_4,v8_4,v9_4,v10_4,v11_4,v12_4,v13_4,v14_4,v15_4) = g_total (v0_3,v1_3,v2_3,v3_3,v4_3,v5_3,v6_3,v7_3,v8_3,v9_3,v10_3,v11_3,v12_3,v13_3,v14_3,v15_3)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma4 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_5,v1_5,v2_5,v3_5,v4_5,v5_5,v6_5,v7_5,v8_5,v9_5,v10_5,v11_5,v12_5,v13_5,v14_5,v15_5) = g_total (v0_4,v1_4,v2_4,v3_4,v4_4,v5_4,v6_4,v7_4,v8_4,v9_4,v10_4,v11_4,v12_4,v13_4,v14_4,v15_4)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma5 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_6,v1_6,v2_6,v3_6,v4_6,v5_6,v6_6,v7_6,v8_6,v9_6,v10_6,v11_6,v12_6,v13_6,v14_6,v15_6) = g_total (v0_5,v1_5,v2_5,v3_5,v4_5,v5_5,v6_5,v7_5,v8_5,v9_5,v10_5,v11_5,v12_5,v13_5,v14_5,v15_5)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma6 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_7,v1_7,v2_7,v3_7,v4_7,v5_7,v6_7,v7_7,v8_7,v9_7,v10_7,v11_7,v12_7,v13_7,v14_7,v15_7) = g_total (v0_6,v1_6,v2_6,v3_6,v4_6,v5_6,v6_6,v7_6,v8_6,v9_6,v10_6,v11_6,v12_6,v13_6,v14_6,v15_6)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma7 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_8,v1_8,v2_8,v3_8,v4_8,v5_8,v6_8,v7_8,v8_8,v9_8,v10_8,v11_8,v12_8,v13_8,v14_8,v15_8) = g_total (v0_7,v1_7,v2_7,v3_7,v4_7,v5_7,v6_7,v7_7,v8_7,v9_7,v10_7,v11_7,v12_7,v13_7,v14_7,v15_7)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma8 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_9,v1_9,v2_9,v3_9,v4_9,v5_9,v6_9,v7_9,v8_9,v9_9,v10_9,v11_9,v12_9,v13_9,v14_9,v15_9) = g_total (v0_8,v1_8,v2_8,v3_8,v4_8,v5_8,v6_8,v7_8,v8_8,v9_8,v10_8,v11_8,v12_8,v13_8,v14_8,v15_8)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+
+def (m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) = sigma9 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15);
+def (v0_10,v1_10,v2_10,v3_10,v4_10,v5_10,v6_10,v7_10,v8_10,v9_10,v10_10,v11_10,v12_10,v13_10,v14_10,v15_10) = g_total (v0_9,v1_9,v2_9,v3_9,v4_9,v5_9,v6_9,v7_9,v8_9,v9_9,v10_9,v11_9,v12_9,v13_9,v14_9,v15_9)(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15);
+// check from reference
+// (v0_10,v1_10,v2_10,v3_10,v4_10,v5_10,v6_10,v7_10,v8_10,v9_10,v10_10,v11_10,v12_10,v13_10,v14_10,v15_10) = (3653866666,3488365222,1879902898,741893902,2942967654,486686451,496943741,2488489893,1050672829,2527062033,4014497313,2788325754,3740207150,2940043489,1317438107,1307245882);
+
+// last step of F function: xor halves and create new h vector
+def xorhalves (h0,h1,h2,h3,h4,h5,h6,h7) (v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15) = {
+    def h0_ = xor32 (xor32 h0 v0) v8;
+    def h1_ = xor32 (xor32 h1 v1) v9;
+    def h2_ = xor32 (xor32 h2 v2) v10;
+    def h3_ = xor32 (xor32 h3 v3) v11;
+    def h4_ = xor32 (xor32 h4 v4) v12;
+    def h5_ = xor32 (xor32 h5 v5) v13;
+    def h6_ = xor32 (xor32 h6 v6) v14;
+    def h7_ = xor32 (xor32 h7 v7) v15;
+    (h0_,h1_,h2_,h3_,h4_,h5_,h6_,h7_)
+};
+
+def (h0_1,h1_1,h2_1,h3_1,h4_1,h5_1,h6_1,h7_1) = xorhalves (h0_0, h1_0, h2_0, h3_0, h4_0, h5_0, h6_0, h7_0)(v0_10,v1_10,v2_10,v3_10,v4_10,v5_10,v6_10,v7_10,v8_10,v9_10,v10_10,v11_10,v12_10,v13_10,v14_10,v15_10);
+// check from reference:
+// (2355006544,3792993330,2737547233,793111374,545998135,691721886,1285265741,2186897286) = (h0_1,h1_1,h2_1,h3_1,h4_1,h5_1,h6_1,h7_1) ;

--- a/tests/ints.pir
+++ b/tests/ints.pir
@@ -1,0 +1,25 @@
+/* An script to test out large integer arithmetic. x must be
+   342342428479792353453543986, c must be -32, and f must be -68. Run
+   as follows:
+   vamp-ir setup params.pp
+   vamp-ir compile tests/ints.pir params.pp circuit.plonk
+   vamp-ir prove circuit.plonk params.pp proof.plonk
+   vamp-ir verify circuit.plonk params.pp proof.plonk
+*/
+
+// Make a large number
+def a = 342342428479792353453543987;
+
+// Check if computations with it are correct;
+a*a = 117198338337441742664441569861251354629164970143856169;
+a+1 = 342342428479792353453543988;
+
+// Check if large int prompts work
+a = x+1;
+
+// Check negative number functioning
+def b = (-8);
+b*4 = c;
+
+// Check alternative radixes
+f = 0x22 * (-0b10);


### PR DESCRIPTION
Made the changes regarding valid int literals in vampir. The changes are as follows:
* Negative integer literals in the prover prompt can now be parsed
* Added support for large integers in vampir source files
* Added some test to exercise this large integer facility

Also added support for vampir source files to contain number literals in alternative bases by using prefixes. Specifically:
* 0x for hexadecimal numbers
* 0b for binary numbers
* 0o for octal numbers
* none for decimal numbers

Additionally, the prover interactive input also supports signed numbers in this form.

Bincode serialization code was added in order to support serialization of ASTs containing `BigInts`.