### PR TITLE
impl or derive PartialEq, Eq, and Hash for TExpr etc

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -119,7 +119,7 @@ pub fn allocate_module_types(
 }
 
 /* A representation of expression types. */
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, Hash)]
 pub enum Type {
     Unit,
     Int,


### PR DESCRIPTION
Derives PartialEq, Eq, and Hash (or implements when necessary) for TExpr etc. in order to build HashMaps of TExprs and compare TExprs for equality