### PR TITLE
Enabled assigning intrinsic functions to variables.

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -880,7 +880,7 @@ fn flatten_binding(
     flattened: &mut Module,
 ) {
     match (&pat.v, &expr.v) {
-        (Pat::Variable(_), Expr::Function(_)) => {},
+        (Pat::Variable(_), Expr::Function(_) | Expr::Intrinsic(_)) => {},
         (Pat::Variable(_),
          Expr::Variable(_) | Expr::Constant(_) |
          Expr::Infix(_, _, _) | Expr::Negate(_)) => {

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -12,14 +12,18 @@ pub x;
 
 def bool x = { x*(x-1) = 0; x };
 
+// Demonstrate that intrinsic functions can be assigned
+
+def myfresh = fresh;
+
 // Extract the 8 bits from a number argument
 
 def range5 a = {
-    def a0 = bool (fresh ((a\1) % 2));
-    def a1 = bool (fresh ((a\2) % 2));
-    def a2 = bool (fresh ((a\4) % 2));
-    def a3 = bool (fresh ((a\8) % 2));
-    def a4 = bool (fresh ((a\16) % 2));
+    def a0 = bool (myfresh ((a\1) % 2));
+    def a1 = bool (myfresh ((a\2) % 2));
+    def a2 = bool (myfresh ((a\4) % 2));
+    def a3 = bool (myfresh ((a\8) % 2));
+    def a4 = bool (myfresh ((a\16) % 2));
     a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4;
     (a0, a1, a2, a3, a4, ())
 };


### PR DESCRIPTION
Enabled intrinsic functions like `fresh`, `iter`, and `fold` to be used as values and added an example exercising this functionality. Did this fix by adding a missing branch to a match statement.