### PR TITLE
Murisi/fresh on composites

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -372,7 +372,9 @@ fn evaluate_binding(
     // Now expand the environment to reflect the binding that has been effected
     let mut new_bindings = HashMap::new();
     for (var, pat) in pat_exps {
-        new_bindings.insert(var, pat.to_expr());
+        if let Some(pat) = pat {
+            new_bindings.insert(var, pat.to_expr());
+        }
     }
     match_pattern_expr(
         &new_binding.0.0,
@@ -1335,18 +1337,37 @@ fn register_fresh_intrinsic(
     );
 }
 
-/* fresh x returns a fresh unconstrained variable whose prover definition equals
- * the supplied expression. */
+/* fresh x returns a fresh unconstrained expression whose prover definition
+ * equals the supplied expression. */
 fn expand_fresh_intrinsic(
     params: &Vec<TPat>,
-    _bindings: &HashMap<VariableId, TExpr>,
+    bindings: &HashMap<VariableId, TExpr>,
     prover_defs: &mut HashSet<VariableId>,
-    _gen: &mut VarGen,
+    gen: &mut VarGen,
 ) -> TExpr {
     match &params[..] {
         [param] if matches!(param.v, Pat::Variable(param_var) if {
-            prover_defs.insert(param_var.id);
-            return param.to_expr();
+            let val = bindings[&param_var.id].clone();
+            // Make a new prover definition that is equal to the argument
+            let fresh_arg = Variable::new(gen.generate_id());
+            let mut fresh_pat = Pat::Variable(fresh_arg.clone()).type_pat(val.t.clone());
+            let mut pat_exps = HashMap::new();
+            // Expand the pattern using our knowledge of the expression's form
+            expand_pattern_variables(&mut fresh_pat, &val, &mut pat_exps, gen);
+            // Make sure every part of expanded expression is a prover variable
+            for var in pat_exps.keys() {
+                prover_defs.insert(*var);
+            }
+            return TExpr {
+                t: val.t.clone(),
+                v: Expr::LetBinding(
+                    LetBinding(
+                        fresh_pat.clone(),
+                        Box::new(val.clone()),
+                    ),
+                    Box::new(fresh_pat.to_expr())
+                ),
+            }
         }) => unreachable!(),
         _ => panic!("unexpected parameters for fresh: {:?}", params),
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -880,7 +880,7 @@ fn flatten_binding(
     flattened: &mut Module,
 ) {
     match (&pat.v, &expr.v) {
-        (Pat::Variable(_), Expr::Function(_)) => {},
+        (Pat::Variable(_), Expr::Function(_) | Expr::Intrinsic(_)) => {},
         (Pat::Variable(_),
          Expr::Variable(_) | Expr::Constant(_) |
          Expr::Infix(_, _, _) | Expr::Negate(_)) => {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -712,12 +712,14 @@ pub fn infer_module_types(
 pub fn expand_pattern_variables(
     pat: &mut TPat,
     expr: &TExpr,
-    map: &mut HashMap<VariableId, TPat>,
+    map: &mut HashMap<VariableId, Option<TPat>>,
     gen: &mut VarGen,
 ) {
     match (&mut pat.v, &expr.v) {
         (Pat::Variable(var), _) if map.contains_key(&var.id) => {
-            *pat = map[&var.id].clone();
+            if let Some(equiv_pat) = &map[&var.id] {
+                *pat = equiv_pat.clone();
+            }
         },
         (Pat::Variable(var), Expr::Product(expr1, expr2)) => {
             let mut new_var1 = Variable::new(gen.generate_id());
@@ -738,7 +740,7 @@ pub fn expand_pattern_variables(
 
             let curr_id = var.id;
             pat.v = Pat::Product(Box::new(var1), Box::new(var2));
-            map.insert(curr_id, pat.clone());
+            map.insert(curr_id, Some(pat.clone()));
         },
 
         (Pat::Variable(var), Expr::Cons(expr1, expr2)) => {
@@ -760,17 +762,21 @@ pub fn expand_pattern_variables(
 
             let curr_id = var.id;
             pat.v = Pat::Cons(Box::new(var1), Box::new(var2));
-            map.insert(curr_id, pat.clone());
+            map.insert(curr_id, Some(pat.clone()));
         },
         (Pat::Variable(var), Expr::Unit) => {
-            map.insert(var.id, Pat::Unit.type_pat(Some(Type::Unit)));
-            *pat = map[&var.id].clone();
+            let equiv_pat = Pat::Unit.type_pat(Some(Type::Unit));
+            map.insert(var.id, Some(equiv_pat.clone()));
+            *pat = equiv_pat;
         },
         (Pat::Variable(var), Expr::Nil) => {
-            map.insert(var.id, Pat::Nil.type_pat(None));
-            *pat = map[&var.id].clone();
+            let equiv_pat = Pat::Nil.type_pat(None);
+            map.insert(var.id, Some(equiv_pat.clone()));
+            *pat = equiv_pat;
         },
-        (Pat::Variable(_), _) => {},
+        (Pat::Variable(var), _) => {
+            map.insert(var.id, None);
+        },
         (Pat::Product(pat1, pat2), Expr::Product(expr1, expr2)) => {
             expand_pattern_variables(pat1, &expr1, map, gen);
             expand_pattern_variables(pat2, &expr2, map, gen);

--- a/tests/fresh.pir
+++ b/tests/fresh.pir
@@ -1,0 +1,30 @@
+/* Any value 0 <= x < 32 such that the last two bits 1, 0 is valid. For example
+   10 is valid since its bit string is ...1010. Run as follows:
+   vamp-ir setup -o params.pp
+   vamp-ir compile -u params.pp -s tests/fresh.pir -o circuit.plonk
+   vamp-ir prove -u params.pp -c circuit.plonk -o proof.plonk
+   vamp-ir verify -u params.pp -c circuit.plonk -p proof.plonk
+*/
+
+pub x;
+
+// Ensure that the given argument is 1 or 0, and returns it
+
+def bool x = { x*(x-1) = 0; x };
+
+// Extract the 8 bits from a number argument
+
+def range5 a = {
+    // Make an expression whose witness is fresh's argument
+    def a0:a1:a2:a3:a4:[] =
+        fresh (((a\1) % 2):((a\2) % 2):((a\4) % 2):((a\8) % 2):((a\16) % 2):[]);
+    def a0 = bool a0;
+    def a1 = bool a1;
+    def a2 = bool a2;
+    def a3 = bool a3;
+    def a4 = bool a4;
+    a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4;
+    (a0, a1, a2, a3, a4, ())
+};
+
+def (0, 1, ar) = range5 x;

--- a/tests/range.pir
+++ b/tests/range.pir
@@ -12,14 +12,18 @@ pub x;
 
 def bool x = { x*(x-1) = 0; x };
 
+// Demonstrate that intrinsic functions can be assigned
+
+def myfresh = fresh;
+
 // Extract the 8 bits from a number argument
 
 def range5 a = {
-    def a0 = bool (fresh ((a\1) % 2));
-    def a1 = bool (fresh ((a\2) % 2));
-    def a2 = bool (fresh ((a\4) % 2));
-    def a3 = bool (fresh ((a\8) % 2));
-    def a4 = bool (fresh ((a\16) % 2));
+    def a0 = bool (myfresh ((a\1) % 2));
+    def a1 = bool (myfresh ((a\2) % 2));
+    def a2 = bool (myfresh ((a\4) % 2));
+    def a3 = bool (myfresh ((a\8) % 2));
+    def a4 = bool (myfresh ((a\16) % 2));
     a = a0 + 2*a1 + 4*a2 + 8*a3 + 16*a4;
     (a0, a1, a2, a3, a4, ())
 };


### PR DESCRIPTION
Made the `fresh` intrinsic work on composite data like lists and made a test for this functionality. Achieved this objective by making the expansions of `fresh` produce new separate prover variables for each part of the composite value that it is supplied.