### PR TITLE
Add quiet flag so it doesn't print as much.

### DIFF
--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -1,7 +1,8 @@
 use crate::ast::Module;
 use crate::halo2::synth::{keygen, make_constant, prover, verifier, Halo2Module, PrimeFieldOps};
+use crate::qprintln;
 use crate::transform::compile;
-use crate::util::{prompt_inputs, read_inputs_from_file};
+use crate::util::{prompt_inputs, read_inputs_from_file, Config};
 
 use halo2_proofs::pasta::{EqAffine, Fp};
 use halo2_proofs::plonk::keygen_vk;
@@ -65,13 +66,13 @@ pub struct Halo2Verify {
 
 /* Implements the subcommand that compiles a vamp-ir file into a Halo2 circuit.
  */
-fn compile_halo2_cmd(Halo2Compile { source, output }: &Halo2Compile) {
-    println!("* Compiling constraints...");
+fn compile_halo2_cmd(Halo2Compile { source, output }: &Halo2Compile, config: &Config) {
+    qprintln!(config, "* Compiling constraints...");
     let unparsed_file = fs::read_to_string(source).expect("cannot read file");
     let module = Module::parse(&unparsed_file).unwrap();
-    let module_3ac = compile(module, &PrimeFieldOps::<Fp>::default());
+    let module_3ac = compile(module, &PrimeFieldOps::<Fp>::default(), config);
 
-    println!("* Synthesizing arithmetic circuit...");
+    qprintln!(config, "* Synthesizing arithmetic circuit...");
     //let circuit = Halo2Module::<Fp>::new(module_3ac.clone());
     let module_rc = Rc::new(module_3ac);
     let circuit = Halo2Module::<Fp>::new(module_rc);
@@ -81,7 +82,7 @@ fn compile_halo2_cmd(Halo2Compile { source, output }: &Halo2Compile) {
         .write(&mut circuit_file)
         .unwrap();
 
-    println!("* Constraint compilation success!");
+    qprintln!(config, "* Constraint compilation success!");
 }
 
 /* Implements the subcommand that creates a proof from interactively entered
@@ -92,8 +93,9 @@ fn prove_halo2_cmd(
         output,
         inputs,
     }: &Halo2Prove,
+    config: &Config,
 ) {
-    println!("* Reading arithmetic circuit...");
+    qprintln!(config, "* Reading arithmetic circuit...");
     let mut circuit_file = File::open(circuit).expect("unable to load circuit file");
 
     let mut expected_path_to_inputs = circuit.clone();
@@ -107,7 +109,8 @@ fn prove_halo2_cmd(
     // Prompt for program inputs
     let var_assignments_ints = match inputs {
         Some(path_to_inputs) => {
-            println!(
+            qprintln!(
+                config,
                 "* Reading inputs from file {}...",
                 path_to_inputs.to_string_lossy()
             );
@@ -115,13 +118,14 @@ fn prove_halo2_cmd(
         }
         None => {
             if expected_path_to_inputs.exists() {
-                println!(
+                qprintln!(
+                    config,
                     "* Reading inputs from file {}...",
                     expected_path_to_inputs.to_string_lossy()
                 );
                 read_inputs_from_file(&circuit.module, &expected_path_to_inputs)
             } else {
-                println!("* Soliciting circuit witnesses...");
+                qprintln!(config, "* Soliciting circuit witnesses...");
                 prompt_inputs(&circuit.module)
             }
         }
@@ -136,45 +140,45 @@ fn prove_halo2_cmd(
     circuit.populate_variables(var_assignments);
 
     // Generating proving key
-    println!("* Generating proving key...");
+    qprintln!(config, "* Generating proving key...");
     let (pk, _vk) = keygen(&circuit, &params);
 
     // Start proving witnesses
-    println!("* Proving knowledge of witnesses...");
+    qprintln!(config, "* Proving knowledge of witnesses...");
     let proof = prover(circuit, &params, &pk);
 
     // verifier(&params, &vk, &proof);
 
-    println!("* Serializing proof to storage...");
+    qprintln!(config, "* Serializing proof to storage...");
     let mut proof_file = File::create(output).expect("unable to create proof file");
     ProofDataHalo2 { proof }
         .serialize(&mut proof_file)
         .expect("Proof serialization failed");
 
-    println!("* Proof generation success!");
+    qprintln!(config, "* Proof generation success!");
 }
 
 /* Implements the subcommand that verifies that a proof is correct. */
-fn verify_halo2_cmd(Halo2Verify { circuit, proof }: &Halo2Verify) {
-    println!("* Reading arithmetic circuit...");
+fn verify_halo2_cmd(Halo2Verify { circuit, proof }: &Halo2Verify, config: &Config) {
+    qprintln!(config, "* Reading arithmetic circuit...");
     let circuit_file = File::open(circuit).expect("unable to load circuit file");
     let HaloCircuitData { params, circuit } = HaloCircuitData::read(&circuit_file).unwrap();
 
-    println!("* Generating verifying key...");
+    qprintln!(config, "* Generating verifying key...");
     let vk = keygen_vk(&params, &circuit).expect("keygen_vk should not fail");
 
-    println!("* Reading zero-knowledge proof...");
+    qprintln!(config, "* Reading zero-knowledge proof...");
     let mut proof_file = File::open(proof).expect("unable to load proof file");
     let ProofDataHalo2 { proof } = ProofDataHalo2::deserialize(&mut proof_file).unwrap();
 
     // Veryfing proof
-    println!("* Verifying proof validity...");
+    qprintln!(config, "* Verifying proof validity...");
     let verifier_result = verifier(&params, &vk, &proof);
 
     if let Ok(()) = verifier_result {
-        println!("* Zero-knowledge proof is valid");
+        qprintln!(config, "* Zero-knowledge proof is valid");
     } else {
-        println!("* Result from verifier: {:?}", verifier_result);
+        qprintln!(config, "* Result from verifier: {:?}", verifier_result);
     }
 }
 
@@ -214,10 +218,10 @@ impl HaloCircuitData {
     }
 }
 
-pub fn halo2(halo2_commands: &Halo2Commands) {
+pub fn halo2(halo2_commands: &Halo2Commands, config: &Config) {
     match halo2_commands {
-        Halo2Commands::Compile(args) => compile_halo2_cmd(args),
-        Halo2Commands::Prove(args) => prove_halo2_cmd(args),
-        Halo2Commands::Verify(args) => verify_halo2_cmd(args),
+        Halo2Commands::Compile(args) => compile_halo2_cmd(args, &config),
+        Halo2Commands::Prove(args) => prove_halo2_cmd(args, &config),
+        Halo2Commands::Verify(args) => verify_halo2_cmd(args, &config),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,16 @@
+use clap::{Parser, Subcommand, ValueEnum};
 use vamp_ir::halo2::cli::{halo2, Halo2Commands};
 use vamp_ir::plonk::cli::{plonk, PlonkCommands};
-use clap::{Parser, Subcommand, ValueEnum};
+use vamp_ir::util::Config;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     backend: Backend,
+
+    #[clap(short, long, default_value = "false")]
+    quiet: bool,
 }
 
 #[derive(Subcommand)]
@@ -29,8 +33,10 @@ enum ProofSystems {
 fn main() {
 
     let cli = Cli::parse();
+    let config = Config { quiet: cli.quiet };
+
     match &cli.backend {
-        Backend::Plonk(plonk_commands) => plonk(plonk_commands),
-        Backend::Halo2(halo2_commands) => halo2(halo2_commands),
+        Backend::Plonk(plonk_commands) => plonk(plonk_commands, &config),
+        Backend::Halo2(halo2_commands) => halo2(halo2_commands, &config),
     }
 }

--- a/src/plonk/cli.rs
+++ b/src/plonk/cli.rs
@@ -1,7 +1,8 @@
 use crate::ast::Module;
 use crate::plonk::synth::{make_constant, PlonkModule, PrimeFieldOps};
+use crate::qprintln;
 use crate::transform::compile;
-use crate::util::{prompt_inputs, read_inputs_from_file};
+use crate::util::{prompt_inputs, read_inputs_from_file, Config};
 
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ec::PairingEngine;
@@ -108,12 +109,12 @@ pub struct PlonkVerify {
     unchecked: bool,
 }
 
-pub fn plonk(plonk_commands: &PlonkCommands) {
+pub fn plonk(plonk_commands: &PlonkCommands, config: &Config) {
     match plonk_commands {
-        PlonkCommands::Setup(args) => setup_plonk_cmd(args),
-        PlonkCommands::Compile(args) => compile_plonk_cmd(args),
-        PlonkCommands::Prove(args) => prove_plonk_cmd(args),
-        PlonkCommands::Verify(args) => verify_plonk_cmd(args),
+        PlonkCommands::Setup(args) => setup_plonk_cmd(args, config),
+        PlonkCommands::Compile(args) => compile_plonk_cmd(args, config),
+        PlonkCommands::Prove(args) => prove_plonk_cmd(args, config),
+        PlonkCommands::Verify(args) => verify_plonk_cmd(args, config),
     }
 }
 
@@ -167,9 +168,10 @@ fn setup_plonk_cmd(
         output,
         unchecked,
     }: &Setup,
+    config: &Config,
 ) {
     // Generate CRS
-    println!("* Setting up public parameters...");
+    qprintln!(config, "* Setting up public parameters...");
     let pp = PC::setup(1 << max_degree, None, &mut OsRng)
         .map_err(to_pc_error::<BlsScalar, PC>)
         .expect("unable to setup polynomial commitment scheme public parameters");
@@ -180,7 +182,7 @@ fn setup_plonk_cmd(
         pp.serialize(&mut pp_file)
     }
     .unwrap();
-    println!("* Public parameter setup success!");
+    qprintln!(config, "* Public parameter setup success!");
 }
 
 /* Implements the subcommand that compiles a vamp-ir file into a PLONK circuit.
@@ -192,13 +194,14 @@ fn compile_plonk_cmd(
         output,
         unchecked,
     }: &PlonkCompile,
+    config: &Config,
 ) {
-    println!("* Compiling constraints...");
+    qprintln!(config, "* Compiling constraints...");
     let unparsed_file = fs::read_to_string(source).expect("cannot read file");
     let module = Module::parse(&unparsed_file).unwrap();
-    let module_3ac = compile(module, &PrimeFieldOps::<BlsScalar>::default());
+    let module_3ac = compile(module, &PrimeFieldOps::<BlsScalar>::default(), config);
 
-    println!("* Reading public parameters...");
+    qprintln!(config, "* Reading public parameters...");
     let mut pp_file = File::open(universal_params).expect("unable to load public parameters file");
     let pp = if *unchecked {
         UniversalParams::deserialize_unchecked(&mut pp_file)
@@ -207,7 +210,7 @@ fn compile_plonk_cmd(
     }
     .unwrap();
 
-    println!("* Synthesizing arithmetic circuit...");
+    qprintln!(config, "* Synthesizing arithmetic circuit...");
     //let mut circuit = PlonkModule::<BlsScalar, JubJubParameters>::new(&module_3ac);
     let module_rc = Rc::new(module_3ac);
     let mut circuit = PlonkModule::<BlsScalar, JubJubParameters>::new(module_rc);
@@ -216,13 +219,13 @@ fn compile_plonk_cmd(
     let (pk_p, vk) = circuit
         .compile::<PC>(&pp)
         .expect("unable to compile circuit");
-    println!("* Serializing circuit to storage...");
+    qprintln!(config, "* Serializing circuit to storage...");
     let mut circuit_file = File::create(output).expect("unable to create circuit file");
     PlonkCircuitData { pk_p, vk, circuit }
         .write(&mut circuit_file)
         .unwrap();
 
-    println!("* Constraint compilation success!");
+    qprintln!(config, "* Constraint compilation success!");
 }
 
 /* Implements the subcommand that creates a proof from interactively entered
@@ -235,8 +238,9 @@ fn prove_plonk_cmd(
         unchecked,
         inputs,
     }: &PlonkProve,
+    config: &Config,
 ) {
-    println!("* Reading arithmetic circuit...");
+    qprintln!(config, "* Reading arithmetic circuit...");
     let mut circuit_file = File::open(circuit).expect("unable to load circuit file");
 
     let mut expected_path_to_inputs = circuit.clone();
@@ -251,7 +255,8 @@ fn prove_plonk_cmd(
     // Prompt for program inputs
     let var_assignments_ints = match inputs {
         Some(path_to_inputs) => {
-            println!(
+            qprintln!(
+                config,
                 "* Reading inputs from file {}...",
                 path_to_inputs.to_string_lossy()
             );
@@ -259,13 +264,14 @@ fn prove_plonk_cmd(
         }
         None => {
             if expected_path_to_inputs.exists() {
-                println!(
+                qprintln!(
+                    config,
                     "* Reading inputs from file {}...",
                     expected_path_to_inputs.to_string_lossy()
                 );
                 read_inputs_from_file(&circuit.module, &expected_path_to_inputs)
             } else {
-                println!("* Soliciting circuit witnesses...");
+                qprintln!(config, "* Soliciting circuit witnesses...");
                 prompt_inputs(&circuit.module)
             }
         }
@@ -279,7 +285,7 @@ fn prove_plonk_cmd(
     // Populate variable definitions
     circuit.populate_variables(var_assignments);
 
-    println!("* Reading public parameters...");
+    qprintln!(config, "* Reading public parameters...");
     let mut pp_file = File::open(universal_params).expect("unable to load public parameters file");
     let pp = if *unchecked {
         UniversalParams::deserialize_unchecked(&mut pp_file)
@@ -289,14 +295,14 @@ fn prove_plonk_cmd(
     .unwrap();
 
     // Start proving witnesses
-    println!("* Proving knowledge of witnesses...");
+    qprintln!(config, "* Proving knowledge of witnesses...");
     let (proof, pi) = circuit.gen_proof::<PC>(&pp, pk_p, b"Test").unwrap();
 
-    println!("* Serializing proof to storage...");
+    qprintln!(config, "* Serializing proof to storage...");
     let mut proof_file = File::create(output).expect("unable to create proof file");
     ProofData { proof, pi }.serialize(&mut proof_file).unwrap();
 
-    println!("* Proof generation success!");
+    qprintln!(config, "* Proof generation success!");
 }
 
 /* Implements the subcommand that verifies that a proof is correct. */
@@ -307,8 +313,9 @@ fn verify_plonk_cmd(
         proof,
         unchecked,
     }: &PlonkVerify,
+    config: &Config,
 ) {
-    println!("* Reading arithmetic circuit...");
+    qprintln!(config, "* Reading arithmetic circuit...");
     let mut circuit_file = File::open(circuit).expect("unable to load circuit file");
     let PlonkCircuitData {
         pk_p: _pk_p,
@@ -316,16 +323,16 @@ fn verify_plonk_cmd(
         circuit,
     } = PlonkCircuitData::read(&mut circuit_file).unwrap();
 
-    println!("* Reading zero-knowledge proof...");
+    qprintln!(config, "* Reading zero-knowledge proof...");
     let mut proof_file = File::open(proof).expect("unable to load proof file");
     let ProofData { proof, pi } = ProofData::deserialize(&mut proof_file).unwrap();
 
-    println!("* Public inputs:");
+    qprintln!(config, "* Public inputs:");
     for (var, val) in circuit.annotate_public_inputs(&vk.1, &pi).values() {
-        println!("{} = {}", var, val);
+        qprintln!(config, "{} = {}", var, val);
     }
 
-    println!("* Reading public parameters...");
+    qprintln!(config, "* Reading public parameters...");
     let mut pp_file = File::open(universal_params).expect("unable to load public parameters file");
     let pp = if *unchecked {
         UniversalParams::deserialize_unchecked(&mut pp_file)
@@ -335,7 +342,7 @@ fn verify_plonk_cmd(
     .unwrap();
 
     // Verifier POV
-    println!("* Verifying proof validity...");
+    qprintln!(config, "* Verifying proof validity...");
     let verifier_data = VerifierData::new(vk.0, pi);
     let verifier_result = verify_proof::<BlsScalar, JubJubParameters, PC>(
         &pp,
@@ -345,8 +352,8 @@ fn verify_plonk_cmd(
         b"Test",
     );
     if let Ok(()) = verifier_result {
-        println!("* Zero-knowledge proof is valid");
+        qprintln!(config, "* Zero-knowledge proof is valid");
     } else {
-        println!("* Result from verifier: {:?}", verifier_result);
+        qprintln!(config, "* Result from verifier: {:?}", verifier_result);
     }
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2,7 +2,9 @@ use crate::ast::{
     Definition, Expr, Function, InfixOp, Intrinsic, LetBinding, Module, Pat, TExpr, TPat, Variable,
     VariableId,
 };
+use crate::qprintln;
 use crate::transform::{collect_pattern_variables, VarGen};
+use crate::util::Config;
 use bincode::{Decode, Encode};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Display};
@@ -819,10 +821,10 @@ pub fn expand_expr_variables(
 }
 
 /* Print out the types of top-level program definitions. */
-pub fn print_types(module: &Module, types: &HashMap<VariableId, Type>) {
+pub fn print_types(module: &Module, types: &HashMap<VariableId, Type>, config: &Config) {
     for def in &module.defs {
         if let Some(typ) = &def.0 .1.t {
-            println!("{}: {}", def.0 .0, expand_type(typ, types));
+            qprintln!(config, "{}: {}", def.0 .0, expand_type(typ, types));
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,3 +120,18 @@ where
     // Combine magnitude and sign
     Ok(if pos { magnitude } else { -magnitude })
 }
+
+// Config to be shuffled around clis.
+pub struct Config {
+    pub quiet: bool,
+}
+
+// Macro for a potentially quiet print line.
+#[macro_export]
+macro_rules! qprintln {
+    ($config:expr, $($arg:tt)*) => {
+        if !$config.quiet {
+            println!($($arg)*);
+        }
+    }
+}


### PR DESCRIPTION
This adds an additional, optional flag to the main cli called "quiet". Using the commands as before will act the same, but putting a "-q" before any of the other commands will prevent them from printing to the command line. For example

```
./target/debug/vamp-ir -q halo2 compile -s tests/bool.pir -o circuit.halo2
./target/debug/vamp-ir -q halo2 prove -c circuit.halo2 -o proof.halo2
./target/debug/vamp-ir -q halo2 verify -c circuit.halo2 -p proof.halo2
```

will only print `** a[12] (private): ` when a witness is required. Without the `-q`, it will print the same as before.

To facilitate this, I made the following changes;

To utils I added a `Config` struct which currently only contains the quiet boolean. This is generated at the main command line and sent to subsequent cli functions. Those functions have been modified to accept a Config argument.

To utils I also added a `qprintln` macro which acts just like `println`, but it takes a Config as an additional argument, and doesn't print anything if `quiet` is true.

All instances of println have been replaced with qprintln.

Closes #92 