### PR TITLE
Add errors

### DIFF
--- a/benches/halo2_benches.rs
+++ b/benches/halo2_benches.rs
@@ -65,7 +65,7 @@ fn bench(pir_file: &str) {
     // Generating proving key
     println!("* Generating proving key...");
     let inst8 = Instant::now();
-    let (pk, _vk) = keygen(&circuit, &params);
+    let (pk, _vk) = keygen(&circuit, &params).expect("Keygen failed in halo2 benchmark");
     let inst9 = Instant::now();
     file.write_all(format!("Generating proving key time: {:?}\n", inst9.duration_since(inst8)).as_bytes()).unwrap();
 
@@ -73,7 +73,7 @@ fn bench(pir_file: &str) {
     // Start proving witnesses
     println!("* Proving knowledge of witnesses...");
     let inst10 = Instant::now();
-    let proof = prover(circuit.clone(), &params, &pk);
+    let proof = prover(circuit.clone(), &params, &pk).expect("prover failed in halo2 benchmark");
     let inst11 = Instant::now();
     file.write_all(format!("Proving knowledge of witnesses time: {:?}\n", inst11.duration_since(inst10)).as_bytes()).unwrap();
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,8 +1,9 @@
+use crate::error::Error;
 use crate::pest::Parser;
 use crate::transform::VarGen;
 use crate::typecheck::Type;
 use crate::util::parse_prefixed_num;
-use bincode::{Decode, Encode, impl_borrow_decode};
+use bincode::{impl_borrow_decode, Decode, Encode};
 use num_bigint::BigInt;
 use pest::iterators::Pair;
 use std::collections::{HashMap, HashSet};
@@ -1028,8 +1029,12 @@ impl fmt::Display for Function {
 }
 
 /* The underlying function that expands an intrinsic call. */
-type IntrinsicImp =
-    fn(&Vec<TPat>, &HashMap<VariableId, TExpr>, &mut HashSet<VariableId>, &mut VarGen) -> TExpr;
+type IntrinsicImp = fn(
+    &Vec<TPat>,
+    &HashMap<VariableId, TExpr>,
+    &mut HashSet<VariableId>,
+    &mut VarGen,
+) -> Result<TExpr, Error>;
 
 #[derive(Clone)]
 pub struct Intrinsic {
@@ -1092,7 +1097,7 @@ impl Intrinsic {
         bindings: &HashMap<VariableId, TExpr>,
         prover_defs: &mut HashSet<VariableId>,
         gen: &mut VarGen,
-    ) -> TExpr {
+    ) -> Result<TExpr, Error> {
         (self.imp)(&self.params, bindings, prover_defs, gen)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::ast::{TExpr, TPat};
+use crate::{ast::{TExpr, TPat, Variable}, typecheck::Type};
 
 #[derive(Debug)]
 pub enum Error {
@@ -21,19 +21,14 @@ pub enum Error {
     // cannot statically match {} against {}
     StaticMatchError { expr: TExpr, pat: TPat },
 
-    MatchError { expr: TExpr, pat: TPat },
+    // cannot match {} to any pattern in {}
+    MatchError { expr1: TExpr, expr2: TExpr },
 
     // only list arguments to fold supported
     NonListArgumentsInFoldError,
 
     // encountered unexpected expression: {}
     UnexpectedExpression { expr: TExpr },
-
-    // encountered unexpected pattern: {}
-    UnexpectedPattern { pat: TPat },
-
-    // only variable patterns should be present at this stage
-    UnexpectedNonVariablePattern,
 
     // unexpected parameters for fresh: {:?}
     UnexpectedFreshParameters { params: Vec<TPat> },
@@ -43,7 +38,36 @@ pub enum Error {
 
     // unexpected arguments to fold: {:?}
     UnexpectedArgumentsInFold { params: Vec<TPat> },
+    
+    // functions should have at least one parameter
+    NoParameterInFunction,
+
     // Type errors
+
+    // universally quantified types cannot be occurs checked
+    OccursCheckError,
+
+    // unable to match {:?} with {}
+    VariableTypeError {v: Variable, t: Type},
+
+    // unable to match {} with {}
+    TypeError {t1: Type, t2: Type},
+
+
+    // pattern {} cannot match {}
+    PatternMatchError { pat: TPat, expr: TExpr},
+
+    // the global function {} is undefined
+    UndefinedGlobalFunction { v: Variable },
+
+    // unable to determine type of global variable {}
+    UnableDetermineType { v: Variable },
+
+    // expression {} cannot have type {}
+    ImpossibleType { e: TExpr, t: Type},
+
+    // the global list {} is undefined
+    UndefinedGlobalList { v: Variable },
 }
 
 // pub enum ParseError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     NonConstantIterArgumentError,
 
     // cannot statically match {} against {}
+    StaticMatchError { expr: TExpr, pat: TPat },
+
     MatchError { expr: TExpr, pat: TPat },
 
     // only list arguments to fold supported

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-use crate::{ast::{TExpr, TPat, Variable}, typecheck::Type};
+use crate::{
+    ast::{TExpr, TPat, Variable},
+    typecheck::Type,
+};
 
 #[derive(Debug)]
 pub enum Error {
@@ -36,7 +39,7 @@ pub enum Error {
 
     // unexpected arguments to fold: {:?}
     UnexpectedArgumentsInFold { params: Vec<TPat> },
-    
+
     // functions should have at least one parameter
     NoParameterInFunction,
 
@@ -46,13 +49,13 @@ pub enum Error {
     OccursCheckError,
 
     // unable to match {:?} with {}
-    VariableTypeError {v: Variable, t: Type},
+    VariableTypeError { v: Variable, t: Type },
 
     // unable to match {} with {}
-    TypeError {t1: Type, t2: Type},
+    TypeError { t1: Type, t2: Type },
 
     // pattern {} cannot match {}
-    PatternMatchError { p: TPat, e: TExpr},
+    PatternMatchError { p: TPat, e: TExpr },
 
     // the global function {} is undefined
     UndefinedGlobalFunction { v: Variable },
@@ -61,7 +64,7 @@ pub enum Error {
     UnableDetermineType { v: Variable },
 
     // expression {} cannot have type {}
-    ImpossibleType { e: TExpr, t: Type},
+    ImpossibleType { e: TExpr, t: Type },
 
     // the global list {} is undefined
     UndefinedGlobalList { v: Variable },
@@ -70,109 +73,111 @@ pub enum Error {
     InsufficientParameters,
 
     // general error from backend
-    BackendError {e: String},
+    BackendError { e: String },
 
     // proof fails to verify
     ProofVerificationFailure,
 }
 
-
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             // cannot apply {} to {}
-            Self::ApplicationError { e2,e1 } => 
-                write!(f, "Cannot apply {} to {}", e2, e1),
+            Self::ApplicationError { e2, e1 } => write!(f, "Cannot apply {} to {}", e2, e1),
 
             // enountered empty sequence
-            Self::EmptySequenceError =>
-                write!(f, "Enountered empty sequence"),
+            Self::EmptySequenceError => write!(f, "Enountered empty sequence"),
 
             // variables are not permitted in expression exponents
-            Self::VariableExponentError =>
-                write!(f, "Variables are not permitted in expression exponents"),
+            Self::VariableExponentError => {
+                write!(f, "Variables are not permitted in expression exponents")
+            }
 
             // only constant arguments to iter supported
-            Self::NonConstantIterArgumentError =>
-                write!(f, "Only constant arguments to iter supported"),
+            Self::NonConstantIterArgumentError => {
+                write!(f, "Only constant arguments to iter supported")
+            }
 
             // cannot statically match {} against {}
-            Self::StaticMatchError { e, p } =>
-                write!(f, "Cannot statically match {} against {}", e, p),
+            Self::StaticMatchError { e, p } => {
+                write!(f, "Cannot statically match {} against {}", e, p)
+            }
 
             // cannot match {} to any pattern in {}
-            Self::MatchError { e1, e2 } =>
-                write!(f, "Cannot match {} to any pattern in {}", e1, e2),
+            Self::MatchError { e1, e2 } => {
+                write!(f, "Cannot match {} to any pattern in {}", e1, e2)
+            }
 
             // only list arguments to fold supported
-            Self::NonListArgumentsInFoldError =>
-                write!(f, "Only list arguments to fold supported"),
+            Self::NonListArgumentsInFoldError => write!(f, "Only list arguments to fold supported"),
 
             // encountered unexpected expression: {}
-            Self::UnexpectedExpression { e } =>
-                write!(f, "Encountered unexpected expression: {}", e),
+            Self::UnexpectedExpression { e } => {
+                write!(f, "Encountered unexpected expression: {}", e)
+            }
 
             // unexpected parameters for fresh: {:?}
-            Self::UnexpectedFreshParameters { params } =>
-                write!(f, "unexpected parameters for fresh: {:?}", params),
+            Self::UnexpectedFreshParameters { params } => {
+                write!(f, "unexpected parameters for fresh: {:?}", params)
+            }
 
             // unexpected arguments to iter: {:?}
-            Self::UnexpectedIterArguments { params} =>
-                write!(f, "Unexpected arguments to iter: {:?}", params),
+            Self::UnexpectedIterArguments { params } => {
+                write!(f, "Unexpected arguments to iter: {:?}", params)
+            }
 
             // unexpected arguments to fold: {:?}
-            Self::UnexpectedArgumentsInFold { params} =>
-                write!(f, "Unexpected arguments to fold: {:?}", params),          
+            Self::UnexpectedArgumentsInFold { params } => {
+                write!(f, "Unexpected arguments to fold: {:?}", params)
+            }
 
             // functions should have at least one parameter
-            Self::NoParameterInFunction =>
-                write!(f, "Functions should have at least one parameter"),
-                
+            Self::NoParameterInFunction => {
+                write!(f, "Functions should have at least one parameter")
+            }
+
             // Type errors
 
             // universally quantified types cannot be occurs checked
-            Self::OccursCheckError =>
-                write!(f, "Universally quantified types cannot be occurs-checked"),
+            Self::OccursCheckError => {
+                write!(f, "Universally quantified types cannot be occurs-checked")
+            }
 
             // unable to match {:?} with {}
-            Self::VariableTypeError {v, t} =>
-                write!(f, "Unable to match {:?} with {}", v, t),
-            
+            Self::VariableTypeError { v, t } => write!(f, "Unable to match {:?} with {}", v, t),
+
             // unable to match {} with {}
-            Self::TypeError {t1, t2} =>
-                write!(f, "Unable to match {} with {}", t1, t2),
-            
+            Self::TypeError { t1, t2 } => write!(f, "Unable to match {} with {}", t1, t2),
+
             // pattern {} cannot match {}
-            Self::PatternMatchError { p, e} =>
-                write!(f, "Pattern {} cannot match {}", p, e),
-            
+            Self::PatternMatchError { p, e } => write!(f, "Pattern {} cannot match {}", p, e),
+
             // the global function {} is undefined
-            Self::UndefinedGlobalFunction { v } =>
-                write!(f, "The global function {} is undefined", v),
-            
+            Self::UndefinedGlobalFunction { v } => {
+                write!(f, "The global function {} is undefined", v)
+            }
+
             // unable to determine type of global variable {}
-            Self::UnableDetermineType { v } =>
-                write!(f, "Unable to determine type of global variable {}: was this variable never used?", v),
-            
+            Self::UnableDetermineType { v } => write!(
+                f,
+                "Unable to determine type of global variable {}: was this variable never used?",
+                v
+            ),
+
             // expression {} cannot have type {}
-            Self::ImpossibleType { e, t} =>
-                write!(f, "Expression {} cannot have type {}", e, t),
+            Self::ImpossibleType { e, t } => write!(f, "Expression {} cannot have type {}", e, t),
 
             // the global list {} is undefined
-            Self::UndefinedGlobalList { v } =>
-            write!(f, "The global list {} is undefined", v),
-            
+            Self::UndefinedGlobalList { v } => write!(f, "The global list {} is undefined", v),
+
             // not enough parameters are available for this circuit
-            Self::InsufficientParameters => 
-                write!(f, "Not enough parameters"),
+            Self::InsufficientParameters => write!(f, "Not enough parameters"),
 
             // general error from backend
-            Self::BackendError {e} =>
-                write!(f, "Error in backend: {}", e),
+            Self::BackendError { e } => write!(f, "Error in backend: {}", e),
 
             // proof fails to verify
-            Self::ProofVerificationFailure => 
-                write!(f, "Proof failed to verify"),
+            Self::ProofVerificationFailure => write!(f, "Proof failed to verify"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,12 +2,10 @@ use crate::{ast::{TExpr, TPat, Variable}, typecheck::Type};
 
 #[derive(Debug)]
 pub enum Error {
-    // Parse errors
-
     // Compilation errors
 
     // cannot apply {} to {}
-    ApplicationError { expr2: TExpr, expr1: TExpr },
+    ApplicationError { e2: TExpr, e1: TExpr },
 
     // enountered empty sequence
     EmptySequenceError,
@@ -19,16 +17,16 @@ pub enum Error {
     NonConstantIterArgumentError,
 
     // cannot statically match {} against {}
-    StaticMatchError { expr: TExpr, pat: TPat },
+    StaticMatchError { e: TExpr, p: TPat },
 
     // cannot match {} to any pattern in {}
-    MatchError { expr1: TExpr, expr2: TExpr },
+    MatchError { e1: TExpr, e2: TExpr },
 
     // only list arguments to fold supported
     NonListArgumentsInFoldError,
 
     // encountered unexpected expression: {}
-    UnexpectedExpression { expr: TExpr },
+    UnexpectedExpression { e: TExpr },
 
     // unexpected parameters for fresh: {:?}
     UnexpectedFreshParameters { params: Vec<TPat> },
@@ -55,7 +53,7 @@ pub enum Error {
 
 
     // pattern {} cannot match {}
-    PatternMatchError { pat: TPat, expr: TExpr},
+    PatternMatchError { p: TPat, e: TExpr},
 
     // the global function {} is undefined
     UndefinedGlobalFunction { v: Variable },
@@ -68,24 +66,120 @@ pub enum Error {
 
     // the global list {} is undefined
     UndefinedGlobalList { v: Variable },
+
+    // Proof System errors
+    InsufficientParameters,
+    MalformedParameters,
+    MalformedProof,
+    MalformedProverKey,
+    MalformedVerifierKey,
+    ProofVerificationFailure,
 }
 
-// pub enum ParseError {
 
-// }
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // cannot apply {} to {}
+            Self::ApplicationError { e2,e1 } => 
+                write!(f, "cannot apply {} to {}", e2, e1),
 
-// pub enum TypeError {
+            // enountered empty sequence
+            Self::EmptySequenceError =>
+                write!(f, "enountered empty sequence"),
 
-// }
+            // variables are not permitted in expression exponents
+            Self::VariableExponentError =>
+                write!(f, "variables are not permitted in expression exponents"),
 
-// pub enum CompileError {
+            // only constant arguments to iter supported
+            Self::NonConstantIterArgumentError =>
+                write!(f, "only constant arguments to iter supported"),
 
-// }
+            // cannot statically match {} against {}
+            Self::StaticMatchError { e, p } =>
+                write!(f, "cannot statically match {} against {}", e, p),
 
-// pub enum ProofError {
-//     TooFewParameters,
-// }
+            // cannot match {} to any pattern in {}
+            Self::MatchError { e1, e2 } =>
+                write!(f, "cannot match {} to any pattern in {}", e1, e2),
 
-// pub enum VerifyError {
-//     ProofVerificationError,
-// }
+            // only list arguments to fold supported
+            Self::NonListArgumentsInFoldError =>
+                write!(f, "only list arguments to fold supported"),
+
+            // encountered unexpected expression: {}
+            Self::UnexpectedExpression { e } =>
+                write!(f, "encountered unexpected expression: {}", e),
+
+            // unexpected parameters for fresh: {:?}
+            Self::UnexpectedFreshParameters { params } =>
+                write!(f, "unexpected parameters for fresh: {:?}", params),
+
+            // unexpected arguments to iter: {:?}
+            Self::UnexpectedIterArguments { params} =>
+                write!(f, "unexpected arguments to iter: {:?}", params),
+
+            // unexpected arguments to fold: {:?}
+            Self::UnexpectedArgumentsInFold { params} =>
+                write!(f, "unexpected arguments to fold: {:?}", params),          
+
+            // functions should have at least one parameter
+            Self::NoParameterInFunction =>
+                write!(f, "functions should have at least one parameter"),
+                
+            // Type errors
+
+            // universally quantified types cannot be occurs checked
+            Self::OccursCheckError =>
+                write!(f, "universally quantified types cannot be occurs checked"),
+
+            // unable to match {:?} with {}
+            Self::VariableTypeError {v, t} =>
+                write!(f, "unable to match {:?} with {}", v, t),
+            
+            // unable to match {} with {}
+            Self::TypeError {t1, t2} =>
+                write!(f, "unable to match {} with {}", t1, t2),
+            
+            // pattern {} cannot match {}
+            Self::PatternMatchError { p, e} =>
+                write!(f, "pattern {} cannot match {}", p, e),
+            
+            // the global function {} is undefined
+            Self::UndefinedGlobalFunction { v } =>
+                write!(f, "the global function {} is undefined", v),
+            
+            // unable to determine type of global variable {}
+            Self::UnableDetermineType { v } =>
+                write!(f, "unable to determine type of global variable {}", v),
+            
+            // expression {} cannot have type {}
+            Self::ImpossibleType { e, t} =>
+                write!(f, "expression {} cannot have type {}", e, t),
+            
+            // the global list {} is undefined
+            Self::UndefinedGlobalList { v } =>
+                write!(f, "the global list {} is undefined", v),
+            
+            // Proof System errors
+            Self::InsufficientParameters =>
+                write!(f, "not enough parameters"),
+            
+            Self::MalformedParameters =>
+                write!(f, "malformed parameters"),
+            
+            Self::MalformedProof =>
+                write!(f, "malformed proof"),
+            
+            Self::MalformedProverKey =>
+                write!(f, "malformed prover key"),
+            
+            Self::MalformedVerifierKey =>
+                write!(f, "malformed verifier key"),
+            
+            Self::ProofVerificationFailure =>
+                write!(f, "proof verification failure"),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,65 @@
+use crate::ast::{TExpr, TPat};
+
+#[derive(Debug)]
+pub enum Error {
+    // Parse errors
+
+    // Compilation errors
+
+    // cannot apply {} to {}
+    ApplicationError { expr2: TExpr, expr1: TExpr },
+
+    // enountered empty sequence
+    EmptySequenceError,
+
+    // variables are not permitted in expression exponents
+    VariableExponentError,
+
+    // only constant arguments to iter supported
+    NonConstantIterArgumentError,
+
+    // cannot statically match {} against {}
+    MatchError { expr: TExpr, pat: TPat },
+
+    // only list arguments to fold supported
+    NonListArgumentsInFoldError,
+
+    // encountered unexpected expression: {}
+    UnexpectedExpression { expr: TExpr },
+
+    // encountered unexpected pattern: {}
+    UnexpectedPattern { pat: TPat },
+
+    // only variable patterns should be present at this stage
+    UnexpectedNonVariablePattern,
+
+    // unexpected parameters for fresh: {:?}
+    UnexpectedFreshParameters { params: Vec<TPat> },
+
+    // unexpected arguments to iter: {:?}
+    UnexpectedIterArguments { params: Vec<TPat> },
+
+    // unexpected arguments to fold: {:?}
+    UnexpectedArgumentsInFold { params: Vec<TPat> },
+    // Type errors
+}
+
+// pub enum ParseError {
+
+// }
+
+// pub enum TypeError {
+
+// }
+
+// pub enum CompileError {
+
+// }
+
+// pub enum ProofError {
+//     TooFewParameters,
+// }
+
+// pub enum VerifyError {
+//     ProofVerificationError,
+// }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ pub enum Error {
 
     // Type errors
 
-    // universally quantified types cannot be occurs checked
+    // universally quantified types cannot be occurs-checked
     OccursCheckError,
 
     // unable to match {:?} with {}
@@ -50,7 +50,6 @@ pub enum Error {
 
     // unable to match {} with {}
     TypeError {t1: Type, t2: Type},
-
 
     // pattern {} cannot match {}
     PatternMatchError { p: TPat, e: TExpr},
@@ -73,6 +72,8 @@ pub enum Error {
     MalformedProof,
     MalformedProverKey,
     MalformedVerifierKey,
+    MalformedWitness,
+    MalformedPublicInput,
     ProofVerificationFailure,
 }
 
@@ -178,8 +179,47 @@ impl std::fmt::Display for Error {
             Self::MalformedVerifierKey =>
                 write!(f, "malformed verifier key"),
             
+            Self::MalformedWitness =>
+                write!(f, "malformed witness"),
+
+            Self::MalformedPublicInput =>
+                write!(f, "malformed public input"),
+            
             Self::ProofVerificationFailure =>
                 write!(f, "proof verification failure"),
+        }
+    }
+}
+
+impl From<plonk_core::error::Error> for Error {
+    fn from(error: plonk_core::error::Error) -> Self {
+        match error {
+            plonk_core::prelude::Error::InvalidEvalDomainSize { log_size_of_group, adicity } => todo!(),
+            plonk_core::prelude::Error::ProofVerificationError => Self::ProofVerificationFailure,
+            plonk_core::prelude::Error::CircuitInputsNotFound => todo!(),
+            plonk_core::prelude::Error::UninitializedPIGenerator => todo!(),
+            plonk_core::prelude::Error::InvalidPublicInputBytes => Self::MalformedPublicInput,
+            plonk_core::prelude::Error::InvalidPublicInputValue => Self::MalformedPublicInput,
+            plonk_core::prelude::Error::CircuitAlreadyPreprocessed => todo!(),
+            plonk_core::prelude::Error::MismatchedPolyLen => todo!(),
+            plonk_core::prelude::Error::PCError { error } => 
+                match error.as_ref() {
+                    "Polynomial Commitment Error: TrimmingDegreeTooLarge" => Self::InsufficientParameters,
+                    _ => Self::MalformedParameters
+                }
+            plonk_core::prelude::Error::DegreeIsZero => todo!(),
+            plonk_core::prelude::Error::TruncatedDegreeTooLarge => todo!(),
+            plonk_core::prelude::Error::TruncatedDegreeIsZero => todo!(),
+            plonk_core::prelude::Error::PolynomialDegreeTooLarge => todo!(),
+            plonk_core::prelude::Error::PolynomialDegreeIsZero => todo!(),
+            plonk_core::prelude::Error::PairingCheckFailure => todo!(),
+            plonk_core::prelude::Error::NotEnoughBytes => todo!(),
+            plonk_core::prelude::Error::PointMalformed => todo!(),
+            plonk_core::prelude::Error::ScalarMalformed => todo!(),
+            plonk_core::prelude::Error::ElementNotIndexed => todo!(),
+            plonk_core::prelude::Error::TablePreProcessingError => todo!(),
+            
+
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -190,36 +190,3 @@ impl std::fmt::Display for Error {
         }
     }
 }
-
-impl From<plonk_core::error::Error> for Error {
-    fn from(error: plonk_core::error::Error) -> Self {
-        match error {
-            plonk_core::prelude::Error::InvalidEvalDomainSize { log_size_of_group, adicity } => todo!(),
-            plonk_core::prelude::Error::ProofVerificationError => Self::ProofVerificationFailure,
-            plonk_core::prelude::Error::CircuitInputsNotFound => todo!(),
-            plonk_core::prelude::Error::UninitializedPIGenerator => todo!(),
-            plonk_core::prelude::Error::InvalidPublicInputBytes => Self::MalformedPublicInput,
-            plonk_core::prelude::Error::InvalidPublicInputValue => Self::MalformedPublicInput,
-            plonk_core::prelude::Error::CircuitAlreadyPreprocessed => todo!(),
-            plonk_core::prelude::Error::MismatchedPolyLen => todo!(),
-            plonk_core::prelude::Error::PCError { error } => 
-                match error.as_ref() {
-                    "Polynomial Commitment Error: TrimmingDegreeTooLarge" => Self::InsufficientParameters,
-                    _ => Self::MalformedParameters
-                }
-            plonk_core::prelude::Error::DegreeIsZero => todo!(),
-            plonk_core::prelude::Error::TruncatedDegreeTooLarge => todo!(),
-            plonk_core::prelude::Error::TruncatedDegreeIsZero => todo!(),
-            plonk_core::prelude::Error::PolynomialDegreeTooLarge => todo!(),
-            plonk_core::prelude::Error::PolynomialDegreeIsZero => todo!(),
-            plonk_core::prelude::Error::PairingCheckFailure => todo!(),
-            plonk_core::prelude::Error::NotEnoughBytes => todo!(),
-            plonk_core::prelude::Error::PointMalformed => todo!(),
-            plonk_core::prelude::Error::ScalarMalformed => todo!(),
-            plonk_core::prelude::Error::ElementNotIndexed => todo!(),
-            plonk_core::prelude::Error::TablePreProcessingError => todo!(),
-            
-
-        }
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,14 +66,13 @@ pub enum Error {
     // the global list {} is undefined
     UndefinedGlobalList { v: Variable },
 
-    // Proof System errors
+    // not enough parameters are available for this circuit
     InsufficientParameters,
-    MalformedParameters,
-    MalformedProof,
-    MalformedProverKey,
-    MalformedVerifierKey,
-    MalformedWitness,
-    MalformedPublicInput,
+
+    // general error from backend
+    BackendError {e: String},
+
+    // proof fails to verify
     ProofVerificationFailure,
 }
 
@@ -83,35 +82,35 @@ impl std::fmt::Display for Error {
         match self {
             // cannot apply {} to {}
             Self::ApplicationError { e2,e1 } => 
-                write!(f, "cannot apply {} to {}", e2, e1),
+                write!(f, "Cannot apply {} to {}", e2, e1),
 
             // enountered empty sequence
             Self::EmptySequenceError =>
-                write!(f, "enountered empty sequence"),
+                write!(f, "Enountered empty sequence"),
 
             // variables are not permitted in expression exponents
             Self::VariableExponentError =>
-                write!(f, "variables are not permitted in expression exponents"),
+                write!(f, "Variables are not permitted in expression exponents"),
 
             // only constant arguments to iter supported
             Self::NonConstantIterArgumentError =>
-                write!(f, "only constant arguments to iter supported"),
+                write!(f, "Only constant arguments to iter supported"),
 
             // cannot statically match {} against {}
             Self::StaticMatchError { e, p } =>
-                write!(f, "cannot statically match {} against {}", e, p),
+                write!(f, "Cannot statically match {} against {}", e, p),
 
             // cannot match {} to any pattern in {}
             Self::MatchError { e1, e2 } =>
-                write!(f, "cannot match {} to any pattern in {}", e1, e2),
+                write!(f, "Cannot match {} to any pattern in {}", e1, e2),
 
             // only list arguments to fold supported
             Self::NonListArgumentsInFoldError =>
-                write!(f, "only list arguments to fold supported"),
+                write!(f, "Only list arguments to fold supported"),
 
             // encountered unexpected expression: {}
             Self::UnexpectedExpression { e } =>
-                write!(f, "encountered unexpected expression: {}", e),
+                write!(f, "Encountered unexpected expression: {}", e),
 
             // unexpected parameters for fresh: {:?}
             Self::UnexpectedFreshParameters { params } =>
@@ -119,74 +118,61 @@ impl std::fmt::Display for Error {
 
             // unexpected arguments to iter: {:?}
             Self::UnexpectedIterArguments { params} =>
-                write!(f, "unexpected arguments to iter: {:?}", params),
+                write!(f, "Unexpected arguments to iter: {:?}", params),
 
             // unexpected arguments to fold: {:?}
             Self::UnexpectedArgumentsInFold { params} =>
-                write!(f, "unexpected arguments to fold: {:?}", params),          
+                write!(f, "Unexpected arguments to fold: {:?}", params),          
 
             // functions should have at least one parameter
             Self::NoParameterInFunction =>
-                write!(f, "functions should have at least one parameter"),
+                write!(f, "Functions should have at least one parameter"),
                 
             // Type errors
 
             // universally quantified types cannot be occurs checked
             Self::OccursCheckError =>
-                write!(f, "universally quantified types cannot be occurs checked"),
+                write!(f, "Universally quantified types cannot be occurs-checked"),
 
             // unable to match {:?} with {}
             Self::VariableTypeError {v, t} =>
-                write!(f, "unable to match {:?} with {}", v, t),
+                write!(f, "Unable to match {:?} with {}", v, t),
             
             // unable to match {} with {}
             Self::TypeError {t1, t2} =>
-                write!(f, "unable to match {} with {}", t1, t2),
+                write!(f, "Unable to match {} with {}", t1, t2),
             
             // pattern {} cannot match {}
             Self::PatternMatchError { p, e} =>
-                write!(f, "pattern {} cannot match {}", p, e),
+                write!(f, "Pattern {} cannot match {}", p, e),
             
             // the global function {} is undefined
             Self::UndefinedGlobalFunction { v } =>
-                write!(f, "the global function {} is undefined", v),
+                write!(f, "The global function {} is undefined", v),
             
             // unable to determine type of global variable {}
             Self::UnableDetermineType { v } =>
-                write!(f, "unable to determine type of global variable {}", v),
+                write!(f, "Unable to determine type of global variable {}: was this variable never used?", v),
             
             // expression {} cannot have type {}
             Self::ImpossibleType { e, t} =>
-                write!(f, "expression {} cannot have type {}", e, t),
-            
+                write!(f, "Expression {} cannot have type {}", e, t),
+
             // the global list {} is undefined
             Self::UndefinedGlobalList { v } =>
-                write!(f, "the global list {} is undefined", v),
+            write!(f, "The global list {} is undefined", v),
             
-            // Proof System errors
-            Self::InsufficientParameters =>
-                write!(f, "not enough parameters"),
-            
-            Self::MalformedParameters =>
-                write!(f, "malformed parameters"),
-            
-            Self::MalformedProof =>
-                write!(f, "malformed proof"),
-            
-            Self::MalformedProverKey =>
-                write!(f, "malformed prover key"),
-            
-            Self::MalformedVerifierKey =>
-                write!(f, "malformed verifier key"),
-            
-            Self::MalformedWitness =>
-                write!(f, "malformed witness"),
+            // not enough parameters are available for this circuit
+            Self::InsufficientParameters => 
+                write!(f, "Not enough parameters"),
 
-            Self::MalformedPublicInput =>
-                write!(f, "malformed public input"),
-            
-            Self::ProofVerificationFailure =>
-                write!(f, "proof verification failure"),
+            // general error from backend
+            Self::BackendError {e} =>
+                write!(f, "Error in backend: {}", e),
+
+            // proof fails to verify
+            Self::ProofVerificationFailure => 
+                write!(f, "Proof failed to verify"),
         }
     }
 }

--- a/src/file_gen/cli.rs
+++ b/src/file_gen/cli.rs
@@ -1,10 +1,11 @@
-use crate::ast::{Module, Pat, InfixOp};
-use crate::transform::{compile, collect_module_variables, FieldOps};
+use crate::ast::{InfixOp, Module, Pat};
+use crate::error::Error;
+use crate::transform::{collect_module_variables, compile, FieldOps};
 
-use std::collections::HashMap;
 use serde_json::Map;
+use std::collections::HashMap;
 
-use std::fs; 
+use std::fs;
 
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
@@ -12,14 +13,13 @@ use std::path::PathBuf;
 use num_bigint::BigInt;
 
 use crate::qprintln;
-use crate::util::{Config};
+use crate::util::Config;
 
 #[derive(Subcommand)]
 pub enum GenerateCommands {
     /// Export witnesses into a template JSON file
     WitnessFile(JSONWitnessFile),
 }
-
 
 #[derive(Args)]
 pub struct JSONWitnessFile {
@@ -33,52 +33,64 @@ pub struct JSONWitnessFile {
 
 // Trivial FieldOps for witness file generation
 impl FieldOps for () {
-    fn canonical(&self, a: BigInt) -> BigInt { a }
-    fn negate(&self, a: BigInt) -> BigInt { a }
-    fn infix(&self, _: InfixOp, a: BigInt, _: BigInt) -> BigInt { a }
+    fn canonical(&self, a: BigInt) -> BigInt {
+        a
+    }
+    fn negate(&self, a: BigInt) -> BigInt {
+        a
+    }
+    fn infix(&self, _: InfixOp, a: BigInt, _: BigInt) -> BigInt {
+        a
+    }
 }
 
 /* Implements the subcommand that writes witnesses to a JSON file. */
-pub fn witness_file_cmd(JSONWitnessFile { source, output }: &JSONWitnessFile, config: &Config) {
+pub fn witness_file_cmd(
+    JSONWitnessFile { source, output }: &JSONWitnessFile,
+    config: &Config,
+) -> Result<(), Error> {
     qprintln!(config, "** Reading file...");
     let unparsed_file = fs::read_to_string(source).expect("cannot read file");
     let module = Module::parse(&unparsed_file).unwrap();
     let module_3ac = compile(module.clone(), &(), config);
-    
+
     qprintln!(config, "** Collecting variables...");
     // Collect unbound variables from module
     let mut input_variables = HashMap::new();
     collect_module_variables(&module_3ac, &mut input_variables);
-    
+
     // Defined variables should not be written to file
     for def in &module.defs {
-        if let Pat::Variable(var) = &def.0.0.v {
+        if let Pat::Variable(var) = &def.0 .0.v {
             input_variables.remove(&var.id);
         }
     }
-    
+
     // Put values into a serde JSON friendly format.
     let mut input_variables_m = Map::new();
     for val in input_variables.values() {
-      match &val.name {
-        None => {},
-        Some(x) => { input_variables_m.insert(x.to_string(), "?".into()); }
-      }
+        match &val.name {
+            None => {}
+            Some(x) => {
+                input_variables_m.insert(x.to_string(), "?".into());
+            }
+        }
     }
-    
+
     qprintln!(config, "** Writing witnesses to file...");
     std::fs::write(
         output,
         serde_json::to_string_pretty(&input_variables_m).unwrap(),
-    ).unwrap();
+    )
+    .unwrap();
 
     qprintln!(config, "** Witnesses file generation success!");
+
+    Ok(())
 }
 
-
-pub fn generate(generate_commands: &GenerateCommands, config: &Config) {
+pub fn generate(generate_commands: &GenerateCommands, config: &Config) -> Result<(), Error> {
     match generate_commands {
         GenerateCommands::WitnessFile(args) => witness_file_cmd(args, config),
     }
 }
-

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -175,6 +175,7 @@ fn verify_halo2_cmd(Halo2Verify { circuit, proof }: &Halo2Verify) {
         println!("* Zero-knowledge proof is valid");
     } else {
         println!("* Result from verifier: {:?}", verifier_result);
+        std::process::exit(88);
     }
 }
 

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -1,8 +1,8 @@
 use crate::ast::Module;
+use crate::error::Error;
 use crate::halo2::synth::{keygen, make_constant, prover, verifier, Halo2Module, PrimeFieldOps};
 use crate::transform::compile;
 use crate::util::{prompt_inputs, read_inputs_from_file};
-use crate::error::Error;
 
 use halo2_proofs::pasta::{EqAffine, Fp};
 use halo2_proofs::plonk::keygen_vk;
@@ -140,11 +140,11 @@ fn prove_halo2_cmd(
 
     // Generating proving key
     println!("* Generating proving key...");
-    let (pk, _vk) = keygen(&circuit, &params);
+    let (pk, _vk) = keygen(&circuit, &params)?;
 
     // Start proving witnesses
     println!("* Proving knowledge of witnesses...");
-    let proof = prover(circuit, &params, &pk);
+    let proof = prover(circuit, &params, &pk)?;
 
     // verifier(&params, &vk, &proof);
 
@@ -165,7 +165,7 @@ fn verify_halo2_cmd(Halo2Verify { circuit, proof }: &Halo2Verify) -> Result<(), 
     let HaloCircuitData { params, circuit } = HaloCircuitData::read(&circuit_file).unwrap();
 
     println!("* Generating verifying key...");
-    let vk = keygen_vk(&params, &circuit).expect("keygen_vk should not fail");
+    let vk = keygen_vk(&params, &circuit)?;
 
     println!("* Reading zero-knowledge proof...");
     let mut proof_file = File::open(proof).expect("unable to load proof file");

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -21,7 +21,6 @@ use std::fs;
 use std::fs::File;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::process;
 
 #[derive(Subcommand)]
 pub enum Halo2Commands {
@@ -68,7 +67,10 @@ pub struct Halo2Verify {
 
 /* Implements the subcommand that compiles a vamp-ir file into a Halo2 circuit.
  */
-fn compile_halo2_cmd(Halo2Compile { source, output }: &Halo2Compile) -> Result<(), Error> {
+fn compile_halo2_cmd(
+    Halo2Compile { source, output }: &Halo2Compile,
+    config: &Config,
+) -> Result<(), Error> {
     qprintln!(config, "* Compiling constraints...");
     let unparsed_file = fs::read_to_string(source).expect("cannot read file");
     let module = Module::parse(&unparsed_file).unwrap();
@@ -97,6 +99,7 @@ fn prove_halo2_cmd(
         output,
         inputs,
     }: &Halo2Prove,
+    config: &Config,
 ) -> Result<(), Error> {
     qprintln!(config, "* Reading arithmetic circuit...");
     let mut circuit_file = File::open(circuit).expect("unable to load circuit file");
@@ -163,7 +166,10 @@ fn prove_halo2_cmd(
 }
 
 /* Implements the subcommand that verifies that a proof is correct. */
-fn verify_halo2_cmd(Halo2Verify { circuit, proof }: &Halo2Verify) -> Result<(), Error> {
+fn verify_halo2_cmd(
+    Halo2Verify { circuit, proof }: &Halo2Verify,
+    config: &Config,
+) -> Result<(), Error> {
     qprintln!(config, "* Reading arithmetic circuit...");
     let circuit_file = File::open(circuit).expect("unable to load circuit file");
     let HaloCircuitData { params, circuit } = HaloCircuitData::read(&circuit_file).unwrap();
@@ -183,7 +189,7 @@ fn verify_halo2_cmd(Halo2Verify { circuit, proof }: &Halo2Verify) -> Result<(), 
         qprintln!(config, "* Zero-knowledge proof is valid");
         Ok(())
     } else {
-        qprintln!(config, "* Result from verifier: {:?}", e);
+        qprintln!(config, "* Result from verifier: {:?}", verifier_result);
         Err(Error::ProofVerificationFailure)
     }
 }

--- a/src/halo2/error.rs
+++ b/src/halo2/error.rs
@@ -3,11 +3,13 @@ use crate::error::Error;
 impl From<halo2_proofs::plonk::Error> for Error {
     fn from(error: halo2_proofs::plonk::Error) -> Self {
         match error {
-            halo2_proofs::plonk::Error::Opening =>
-                Self::ProofVerificationFailure,
-            halo2_proofs::plonk::Error::NotEnoughRowsAvailable { current_k: _ } => 
-                Self::InsufficientParameters,
-            _ => Self::BackendError { e:  error.to_string()},
+            halo2_proofs::plonk::Error::Opening => Self::ProofVerificationFailure,
+            halo2_proofs::plonk::Error::NotEnoughRowsAvailable { current_k: _ } => {
+                Self::InsufficientParameters
+            }
+            _ => Self::BackendError {
+                e: error.to_string(),
+            },
         }
     }
 }

--- a/src/halo2/error.rs
+++ b/src/halo2/error.rs
@@ -1,0 +1,13 @@
+use crate::error::Error;
+
+impl From<halo2_proofs::plonk::Error> for Error {
+    fn from(error: halo2_proofs::plonk::Error) -> Self {
+        match error {
+            halo2_proofs::plonk::Error::Opening =>
+                Self::ProofVerificationFailure,
+            halo2_proofs::plonk::Error::NotEnoughRowsAvailable { current_k: _ } => 
+                Self::InsufficientParameters,
+            _ => Self::BackendError { e:  error.to_string()},
+        }
+    }
+}

--- a/src/halo2/mod.rs
+++ b/src/halo2/mod.rs
@@ -1,2 +1,3 @@
 pub mod cli;
 pub mod synth;
+pub mod error;

--- a/src/halo2/mod.rs
+++ b/src/halo2/mod.rs
@@ -1,3 +1,3 @@
 pub mod cli;
-pub mod synth;
 pub mod error;
+pub mod synth;

--- a/src/halo2/synth.rs
+++ b/src/halo2/synth.rs
@@ -1,5 +1,5 @@
-use group::ff::{Field, FromUniformBytes};
 use ff::PrimeField;
+use group::ff::{Field, FromUniformBytes};
 use halo2_proofs::circuit::{Cell, Layouter, SimpleFloorPlanner, Value};
 use halo2_proofs::pasta::{EqAffine, Fp};
 use halo2_proofs::plonk::*;
@@ -150,7 +150,7 @@ where
 
 impl<F> FieldOps for PrimeFieldOps<F>
 where
-    F: ff::FromUniformBytes<64> + std::cmp::Ord ,
+    F: ff::FromUniformBytes<64> + std::cmp::Ord,
 {
     /* Evaluate the given negation expression in the given prime field. */
     fn canonical(&self, a: BigInt) -> BigInt {
@@ -202,11 +202,11 @@ where
                     } else {
                         c.pow(&limbs)
                     }
-                        .to_repr()
-                        .as_ref(),
+                    .to_repr()
+                    .as_ref(),
                 )
-                    .to_bigint()
-                    .unwrap()
+                .to_bigint()
+                .unwrap()
             }
             InfixOp::Equal => panic!("cannot evaluate equals expression"),
         }
@@ -1094,23 +1094,22 @@ impl<F: ff::FromUniformBytes<64> + std::cmp::Ord> Circuit<F> for Halo2Module<F> 
 pub fn keygen(
     circuit: &Halo2Module<Fp>,
     params: &Params<EqAffine>,
-) -> (ProvingKey<EqAffine>, VerifyingKey<EqAffine>) {
-    let vk = keygen_vk(&params, circuit).expect("keygen_vk should not fail");
+) -> Result<(ProvingKey<EqAffine>, VerifyingKey<EqAffine>), Error> {
+    let vk = keygen_vk(&params, circuit)?;
     let vk_return = vk.clone();
-    let pk = keygen_pk(&params, vk, circuit).expect("keygen_pk should not fail");
-    (pk, vk_return)
+    let pk = keygen_pk(&params, vk, circuit)?;
+    Ok((pk, vk_return))
 }
 
 pub fn prover(
     circuit: Halo2Module<Fp>,
     params: &Params<EqAffine>,
     pk: &ProvingKey<EqAffine>,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, Error> {
     let rng = OsRng;
     let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-    create_proof(params, pk, &[circuit], &[&[]], rng, &mut transcript)
-        .expect("proof generation should not fail");
-    transcript.finalize()
+    create_proof(params, pk, &[circuit], &[&[]], rng, &mut transcript)?;
+    Ok(transcript.finalize())
 }
 
 pub fn verifier(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+pub mod error;
 pub mod halo2;
 pub mod plonk;
 pub mod transform;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ fn main() {
 
     let cli = Cli::parse();
     match &cli.backend {
-        Backend::Plonk(plonk_commands) => plonk(plonk_commands),
-        Backend::Halo2(halo2_commands) => halo2(halo2_commands),
-    }
+        Backend::Plonk(plonk_commands) => plonk(plonk_commands).unwrap(),
+        Backend::Halo2(halo2_commands) => halo2(halo2_commands).unwrap(),
+    };
+    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ enum ProofSystems {
 
 /* Main entry point for vamp-ir compiler, prover, and verifier. */
 fn main() {
-
     let cli = Cli::parse();
     let config = Config { quiet: cli.quiet };
 
@@ -39,5 +38,4 @@ fn main() {
         Backend::Plonk(plonk_commands) => plonk(plonk_commands, &config).unwrap(),
         Backend::Halo2(halo2_commands) => halo2(halo2_commands, &config).unwrap(),
     };
-    
 }

--- a/src/plonk/cli.rs
+++ b/src/plonk/cli.rs
@@ -348,5 +348,6 @@ fn verify_plonk_cmd(
         println!("* Zero-knowledge proof is valid");
     } else {
         println!("* Result from verifier: {:?}", verifier_result);
+        std::process::exit(88);
     }
 }

--- a/src/plonk/cli.rs
+++ b/src/plonk/cli.rs
@@ -25,7 +25,6 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::process;
 
 use clap::{Args, Subcommand};
 
@@ -199,7 +198,7 @@ fn compile_plonk_cmd(
         unchecked,
     }: &PlonkCompile,
     config: &Config,
-) -> Result<(), Error>{
+) -> Result<(), Error> {
     qprintln!(config, "* Compiling constraints...");
     let unparsed_file = fs::read_to_string(source).expect("cannot read file");
     let module = Module::parse(&unparsed_file).unwrap();
@@ -220,9 +219,8 @@ fn compile_plonk_cmd(
     let mut circuit = PlonkModule::<BlsScalar, JubJubParameters>::new(module_rc);
 
     // Compile the circuit
-    let (pk_p, vk) = circuit
-        .compile::<PC>(&pp)?;
-        //.expect("unable to compile circuit");
+    let (pk_p, vk) = circuit.compile::<PC>(&pp)?;
+    //.expect("unable to compile circuit");
     qprintln!(config, "* Serializing circuit to storage...");
     let mut circuit_file = File::create(output).expect("unable to create circuit file");
     PlonkCircuitData { pk_p, vk, circuit }

--- a/src/plonk/error.rs
+++ b/src/plonk/error.rs
@@ -3,30 +3,12 @@ use crate::error::Error;
 impl From<plonk_core::error::Error> for Error {
     fn from(error: plonk_core::error::Error) -> Self {
         match error {
-            plonk_core::prelude::Error::InvalidEvalDomainSize { log_size_of_group: _, adicity: _ } => todo!(),
-            plonk_core::prelude::Error::ProofVerificationError => Self::ProofVerificationFailure,
-            plonk_core::prelude::Error::CircuitInputsNotFound => todo!(),
-            plonk_core::prelude::Error::UninitializedPIGenerator => todo!(),
-            plonk_core::prelude::Error::InvalidPublicInputBytes => Self::MalformedPublicInput,
-            plonk_core::prelude::Error::InvalidPublicInputValue => Self::MalformedPublicInput,
-            plonk_core::prelude::Error::CircuitAlreadyPreprocessed => todo!(),
-            plonk_core::prelude::Error::MismatchedPolyLen => todo!(),
-            plonk_core::prelude::Error::PCError { error } => 
+           plonk_core::prelude::Error::PCError { error } => 
                 match error.as_ref() {
                     "Polynomial Commitment Error: TrimmingDegreeTooLarge" => Self::InsufficientParameters,
-                    _ => Self::MalformedParameters
+                    _ => Self::BackendError { e: error.to_string()},
                 }
-            plonk_core::prelude::Error::DegreeIsZero => todo!(),
-            plonk_core::prelude::Error::TruncatedDegreeTooLarge => todo!(),
-            plonk_core::prelude::Error::TruncatedDegreeIsZero => todo!(),
-            plonk_core::prelude::Error::PolynomialDegreeTooLarge => todo!(),
-            plonk_core::prelude::Error::PolynomialDegreeIsZero => todo!(),
-            plonk_core::prelude::Error::PairingCheckFailure => todo!(),
-            plonk_core::prelude::Error::NotEnoughBytes => todo!(),
-            plonk_core::prelude::Error::PointMalformed => todo!(),
-            plonk_core::prelude::Error::ScalarMalformed => todo!(),
-            plonk_core::prelude::Error::ElementNotIndexed => todo!(),
-            plonk_core::prelude::Error::TablePreProcessingError => todo!(),
+        _ => Self::BackendError { e:  error.to_string()},
         }
     }
 }

--- a/src/plonk/error.rs
+++ b/src/plonk/error.rs
@@ -3,12 +3,17 @@ use crate::error::Error;
 impl From<plonk_core::error::Error> for Error {
     fn from(error: plonk_core::error::Error) -> Self {
         match error {
-           plonk_core::prelude::Error::PCError { error } => 
-                match error.as_ref() {
-                    "Polynomial Commitment Error: TrimmingDegreeTooLarge" => Self::InsufficientParameters,
-                    _ => Self::BackendError { e: error.to_string()},
+            plonk_core::prelude::Error::PCError { error } => match error.as_ref() {
+                "Polynomial Commitment Error: TrimmingDegreeTooLarge" => {
+                    Self::InsufficientParameters
                 }
-        _ => Self::BackendError { e:  error.to_string()},
+                _ => Self::BackendError {
+                    e: error.to_string(),
+                },
+            },
+            _ => Self::BackendError {
+                e: error.to_string(),
+            },
         }
     }
 }

--- a/src/plonk/error.rs
+++ b/src/plonk/error.rs
@@ -1,0 +1,32 @@
+use crate::error::Error;
+
+impl From<plonk_core::error::Error> for Error {
+    fn from(error: plonk_core::error::Error) -> Self {
+        match error {
+            plonk_core::prelude::Error::InvalidEvalDomainSize { log_size_of_group: _, adicity: _ } => todo!(),
+            plonk_core::prelude::Error::ProofVerificationError => Self::ProofVerificationFailure,
+            plonk_core::prelude::Error::CircuitInputsNotFound => todo!(),
+            plonk_core::prelude::Error::UninitializedPIGenerator => todo!(),
+            plonk_core::prelude::Error::InvalidPublicInputBytes => Self::MalformedPublicInput,
+            plonk_core::prelude::Error::InvalidPublicInputValue => Self::MalformedPublicInput,
+            plonk_core::prelude::Error::CircuitAlreadyPreprocessed => todo!(),
+            plonk_core::prelude::Error::MismatchedPolyLen => todo!(),
+            plonk_core::prelude::Error::PCError { error } => 
+                match error.as_ref() {
+                    "Polynomial Commitment Error: TrimmingDegreeTooLarge" => Self::InsufficientParameters,
+                    _ => Self::MalformedParameters
+                }
+            plonk_core::prelude::Error::DegreeIsZero => todo!(),
+            plonk_core::prelude::Error::TruncatedDegreeTooLarge => todo!(),
+            plonk_core::prelude::Error::TruncatedDegreeIsZero => todo!(),
+            plonk_core::prelude::Error::PolynomialDegreeTooLarge => todo!(),
+            plonk_core::prelude::Error::PolynomialDegreeIsZero => todo!(),
+            plonk_core::prelude::Error::PairingCheckFailure => todo!(),
+            plonk_core::prelude::Error::NotEnoughBytes => todo!(),
+            plonk_core::prelude::Error::PointMalformed => todo!(),
+            plonk_core::prelude::Error::ScalarMalformed => todo!(),
+            plonk_core::prelude::Error::ElementNotIndexed => todo!(),
+            plonk_core::prelude::Error::TablePreProcessingError => todo!(),
+        }
+    }
+}

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -1,2 +1,3 @@
 pub mod cli;
 pub mod synth;
+pub mod error;

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -1,3 +1,3 @@
 pub mod cli;
-pub mod synth;
 pub mod error;
+pub mod synth;

--- a/src/plonk/synth.rs
+++ b/src/plonk/synth.rs
@@ -208,7 +208,7 @@ where
         for (k, v) in encoded_variable_map {
             variable_map.insert(k, v.0);
         }
-        let module =  Rc::new(Module::decode(decoder)?);
+        let module = Rc::new(Module::decode(decoder)?);
         Ok(PlonkModule {
             module,
             variable_map,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -163,8 +163,8 @@ fn match_pattern_expr(
         (Pat::Constant(a), Expr::Constant(b)) if a != b => Ok(Tribool::False),
         (Pat::Constant(_), Expr::Variable(_) | Expr::Infix(_, _, _)) => Ok(Tribool::Indeterminate),
         _ => Err(Error::StaticMatchError {
-            expr: expr.clone(),
-            pat: pat.clone(),
+            e: expr.clone(),
+            p: pat.clone(),
         }),
     }
 }
@@ -449,7 +449,7 @@ fn capture_env(val: &mut TExpr, new_bindings: HashMap<VariableId, TExpr>) -> Res
         | Expr::Variable(_)
         | Expr::Nil => Ok(()),
         Expr::Application(_, _) | Expr::Sequence(_) | Expr::LetBinding(_, _) | Expr::Match(_) => {
-            Err(Error::UnexpectedExpression { expr: val.clone() })
+            Err(Error::UnexpectedExpression { e: val.clone() })
         }
     }
 }
@@ -552,8 +552,8 @@ fn evaluate(
                     Ok(val)
                 }
                 _ => Err(Error::ApplicationError {
-                    expr2: *expr2.clone(),
-                    expr1: expr1,
+                    e2: *expr2.clone(),
+                    e1: expr1,
                 }),
             }
         }
@@ -777,14 +777,14 @@ fn evaluate(
                     }
                     Tribool::Indeterminate => {
                         return Err(Error::StaticMatchError {
-                            expr: expr.clone(),
-                            pat: pat.clone(),
+                            e: expr.clone(),
+                            p: pat.clone(),
                         })
                     }
                     Tribool::False => continue,
                 }
             }
-            Err(Error::MatchError{expr1: *matche.0.clone(), expr2: expr.clone()})
+            Err(Error::MatchError{e1: *matche.0.clone(), e2: expr.clone()})
         }
     }
 }
@@ -1072,7 +1072,7 @@ fn flatten_expr_to_3ac(
             push_constraint_def(flattened, out.clone(), rhs);
             Ok(out)
         }
-        _ => Err(Error::UnexpectedExpression { expr: expr.clone() }),
+        _ => Err(Error::UnexpectedExpression { e: expr.clone() }),
     }
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -511,9 +511,7 @@ fn evaluate(
                     capture_env(&mut val, new_bindings)?;
                     Ok(val)
                 }
-                Expr::Function(fun) if fun.params.is_empty() => {
-                    Err(Error::NoParameterInFunction)
-                }
+                Expr::Function(fun) if fun.params.is_empty() => Err(Error::NoParameterInFunction),
                 Expr::Function(fun) => {
                     // Now that we have an assignment, move the function
                     // parameter into the environment
@@ -786,7 +784,10 @@ fn evaluate(
                     Tribool::False => continue,
                 }
             }
-            Err(Error::MatchError{e1: *matche.0.clone(), e2: expr.clone()})
+            Err(Error::MatchError {
+                e1: *matche.0.clone(),
+                e2: expr.clone(),
+            })
         }
     }
 }
@@ -1534,7 +1535,9 @@ fn expand_iter_intrinsic(
                 }),
             })
         }
-        _ => Err(Error::UnexpectedIterArguments{params: params.to_vec()})
+        _ => Err(Error::UnexpectedIterArguments {
+            params: params.to_vec(),
+        }),
     }
 }
 
@@ -1618,7 +1621,7 @@ fn expand_fold_intrinsic(
                 } else if let Expr::Nil = &param_val.v {
                     break param_list;
                 } else {
-                    return Err(Error::NonListArgumentsInFoldError)
+                    return Err(Error::NonListArgumentsInFoldError);
                 };
             };
             let mut body = TExpr {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -778,7 +778,7 @@ pub fn expand_pattern_variables(
             expand_pattern_variables(pat1, expr, map, gen)?;
             Ok(())
         }
-        _ => Err(Error::PatternMatchError { expr: expr.clone(), pat: pat.clone() }),
+        _ => Err(Error::PatternMatchError { e: expr.clone(), p: pat.clone() }),
 
     }
 }


### PR DESCRIPTION
Adds Vamp-IR error module. Errors from Plonk and Halo2 backends are converted into Vamp-IR errors and functions that can have an error are rewritten to propagate and report errors. Error messages are all put in the same places so it will be easier to rewrite and edit error messages in the future. Closes #80