### PR TITLE
Implement REPL

### DIFF
--- a/benches/plonk_benches.rs
+++ b/benches/plonk_benches.rs
@@ -161,7 +161,7 @@ fn bench(pir_file: &str, max_degree: u32) {
     if let Ok(()) = verifier_result {
         println!("* Zero-knowledge proof is valid");
     } else {
-        println!("* Result from verifier: {:?}", verifier_result);
+        println!("* Result from verifier: {verifier_result:?}");
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,9 @@ pub enum Error {
 
     // proof fails to verify
     ProofVerificationFailure,
+
+    // invalid field at repl
+    InvalidField,
 }
 
 impl std::fmt::Display for Error {
@@ -177,6 +180,9 @@ impl std::fmt::Display for Error {
 
             // proof fails to verify
             Self::ProofVerificationFailure => write!(f, "Proof failed to verify"),
+
+            // invalid field at repl
+            Self::InvalidField => write!(f, "Invalid field value"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod file_gen;
 pub mod halo2;
 pub mod plonk;
+pub mod repl;
 pub mod transform;
 mod typecheck;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use vamp_ir::error::Error;
 use vamp_ir::file_gen::cli::{generate, GenerateCommands};
 use vamp_ir::halo2::cli::{halo2, Halo2Commands};
 use vamp_ir::plonk::cli::{plonk, PlonkCommands};
+use vamp_ir::repl::cli::{repl, REPL};
 use vamp_ir::util::Config;
-use vamp_ir::repl::cli::{repl, REPLCommands};
 
 const VERIF_FAILURE_CODE: i32 = 1;
 
@@ -26,8 +26,7 @@ enum Backend {
     Plonk(PlonkCommands),
     #[command(subcommand)]
     Halo2(Halo2Commands),
-    #[command(subcommand)]
-    REPL(REPLCommands),
+    REPL(REPL),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use vamp_ir::file_gen::cli::{generate, GenerateCommands};
 use vamp_ir::halo2::cli::{halo2, Halo2Commands};
 use vamp_ir::plonk::cli::{plonk, PlonkCommands};
 use vamp_ir::util::Config;
+use vamp_ir::repl::cli::{repl, REPLCommands};
 
 const VERIF_FAILURE_CODE: i32 = 1;
 
@@ -25,6 +26,8 @@ enum Backend {
     Plonk(PlonkCommands),
     #[command(subcommand)]
     Halo2(Halo2Commands),
+    #[command(subcommand)]
+    REPL(REPLCommands),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -44,6 +47,7 @@ fn main() {
         Backend::Generate(generate_commands) => generate(generate_commands, &config),
         Backend::Plonk(plonk_commands) => plonk(plonk_commands, &config),
         Backend::Halo2(halo2_commands) => halo2(halo2_commands, &config),
+        Backend::REPL(repl_commands) => Ok(repl(repl_commands)),
     };
 
     match res {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
         Backend::Generate(generate_commands) => generate(generate_commands, &config),
         Backend::Plonk(plonk_commands) => plonk(plonk_commands, &config),
         Backend::Halo2(halo2_commands) => halo2(halo2_commands, &config),
-        Backend::REPL(repl_commands) => Ok(repl(repl_commands)),
+        Backend::REPL(repl_commands) => repl(repl_commands),
     };
 
     match res {

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -1,7 +1,7 @@
 use crate::pest::Parser;
 
 use crate::ast::{Definition, Module, Rule, TExpr, VampirParser, Variable};
-use crate::transform::{compile_repl, FieldOps};
+use crate::transform::{compile_repl, compile, FieldOps};
 //use crate::repl::transform::{compile, evaluate_module, collect_module_variables, FieldOps};
 
 use crate::plonk::synth::PrimeFieldOps as PlonkPrimeFieldOps;
@@ -15,6 +15,8 @@ use std::io::Write;
 
 use clap::Args;
 use std::path::PathBuf;
+
+use crate::util::Config;
 
 #[derive(Args)]
 pub struct REPL {
@@ -37,6 +39,8 @@ pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
     } else {
         println!("Entering REPL with no module loaded.");
     }
+
+    compile(module.clone(), field_ops, &Config { quiet: false });
 
     let mut defs: Vec<Definition>;
     let mut exprs: Vec<TExpr>;

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -1,0 +1,93 @@
+use crate::ast::{Module, TExpr, Pat, InfixOp, Expr, Variable};
+use crate::transform::{compile, collect_module_variables, FieldOps};
+
+use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
+use halo2_proofs::pasta::{EqAffine, Fp};
+use crate::plonk::synth::{PrimeFieldOps as PlonkPrimeFieldOps};
+use crate::halo2::synth::{PrimeFieldOps as Halo2PrimeFieldOps};
+
+use std::collections::HashMap;
+use serde_json::Map;
+
+use std::fs; 
+use std::fs::File;
+use std::io::{BufWriter, BufReader, BufRead, Write};
+use std::fs::OpenOptions;
+
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+use num_bigint::BigInt;
+
+
+#[derive(Subcommand)]
+pub enum REPLCommands {
+    /// Run repl evaluated using Halo2 field.
+    Halo2(Halo2),
+    /// Run repl evaluated using Plonk field.
+    Plonk(Plonk),
+}
+
+
+#[derive(Args)]
+pub struct Halo2 {
+    /// Path to source file that is being loaded into repl
+    #[arg(short, long)]
+    source: Option<PathBuf>,
+}
+
+
+#[derive(Args)]
+pub struct Plonk {
+    /// Path to source file that is being loaded into repl
+    #[arg(short, long)]
+    source: Option<PathBuf>,
+}
+
+pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
+    let mut module = Module::default();
+
+    if let Some(path) = source {
+        let unparsed_file = fs::read_to_string(path).expect("cannot read file");
+        module = Module::parse(&unparsed_file).unwrap();
+        println!("Entering REPL with module loaded from file.");
+        // println!("{}", module);
+    } else {
+        println!("Entering REPL with no module loaded.");
+    }
+
+    loop {
+        print!("> ");
+        std::io::stdout().flush().expect("Error flushing stdout");
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input).expect("Error reading from stdin");
+
+        if input.trim() == "quit" || input.trim() == "exit" {
+            break;
+        }
+
+        println!("{}", input);
+    }
+}
+
+
+/* Implements the subcommand that writes witnesses to a JSON file. */
+pub fn halo2_repl_cmd(Halo2 { source }: &Halo2) {
+    println!("** Halo2 Repl");
+    repl_cmd(&source, &Halo2PrimeFieldOps::<Fp>::default());
+}
+
+/* Implements the subcommand that writes circuit into comma separated, three-address file. */
+pub fn plonk_repl_cmd(Plonk { source }: &Plonk) {
+    println!("** Plonk Repl");
+    repl_cmd(&source, &PlonkPrimeFieldOps::<BlsScalar>::default());
+}
+
+pub fn repl(repl_commands: &REPLCommands) {
+    match repl_commands {
+        REPLCommands::Halo2(args) => halo2_repl_cmd(args),
+        REPLCommands::Plonk(args) => plonk_repl_cmd(args),
+    }
+}
+

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -1,49 +1,29 @@
 use crate::pest::Parser;
 
-use crate::ast::{VampirParser, Rule, Module, TExpr, Expr, Definition, Pat, InfixOp, Variable, VariableId};
-use crate::transform::{compile, evaluate_module_repl, collect_module_variables, compile_repl, FieldOps, VarGen};
+use crate::ast::{Definition, Module, Rule, TExpr, VampirParser, Variable};
+use crate::transform::{compile_repl, FieldOps};
 //use crate::repl::transform::{compile, evaluate_module, collect_module_variables, FieldOps};
 
-use ark_bls12_381::{Fr};
-use crate::plonk::synth::{PrimeFieldOps as PlonkPrimeFieldOps};
+use crate::plonk::synth::PrimeFieldOps as PlonkPrimeFieldOps;
+use ark_bls12_381::Fr;
 
-use halo2_proofs::pasta::{Fp};
-use crate::halo2::synth::{PrimeFieldOps as Halo2PrimeFieldOps};
+use crate::halo2::synth::PrimeFieldOps as Halo2PrimeFieldOps;
+use halo2_proofs::pasta::Fp;
 
-use std::fs; 
-use std::fs::File;
-use std::io::{BufWriter, BufReader, BufRead, Write};
-use std::fs::OpenOptions;
-use std::fmt::{Display};
-use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::Write;
 
-use clap::{Args, Subcommand};
+use clap::Args;
 use std::path::PathBuf;
 
-use num_bigint::BigInt;
-
-#[derive(Subcommand)]
-pub enum REPLCommands {
-    /// Run repl evaluated using Halo2 field.
-    Halo2(Halo2),
-    /// Run repl evaluated using Plonk field.
-    Plonk(Plonk),
-}
-
-
 #[derive(Args)]
-pub struct Halo2 {
+pub struct REPL {
     /// Path to source file that is being loaded into repl
     #[arg(short, long)]
     source: Option<PathBuf>,
-}
-
-
-#[derive(Args)]
-pub struct Plonk {
-    /// Path to source file that is being loaded into repl
+    /// Field to compute with
     #[arg(short, long)]
-    source: Option<PathBuf>,
+    field: String,
 }
 
 pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
@@ -58,16 +38,18 @@ pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
         println!("Entering REPL with no module loaded.");
     }
 
-    let mut defs: Vec<Definition> = vec![];
-    let mut exprs: Vec<TExpr> = vec![];
-    let mut pubs: Vec<Variable> = vec![];
+    let mut defs: Vec<Definition>;
+    let mut exprs: Vec<TExpr>;
+    let mut pubs: Vec<Variable>;
 
     loop {
         print!("In : ");
         std::io::stdout().flush().expect("Error flushing stdout");
 
         let mut input: String = String::new();
-        std::io::stdin().read_line(&mut input).expect("Error reading from stdin");
+        std::io::stdin()
+            .read_line(&mut input)
+            .expect("Error reading from stdin");
 
         if input.trim() == "quit" || input.trim() == "exit" {
             break;
@@ -86,53 +68,48 @@ pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
                             exprs.push(expr);
                         }
                         Rule::definition => {
-                            let definition: Definition = Definition::parse(pair).expect("expected definition");
+                            let definition: Definition =
+                                Definition::parse(pair).expect("expected definition");
                             defs.push(definition);
                         }
                         Rule::declaration => {
                             let mut pairs: pest::iterators::Pairs<Rule> = pair.into_inner();
                             while let Some(pair) = pairs.next() {
-                                let var: Variable = Variable::parse(pair).expect("expected variable");
+                                let var: Variable =
+                                    Variable::parse(pair).expect("expected variable");
                                 pubs.push(var);
                             }
                         }
                         Rule::EOI => continue,
-                        _ => unreachable!("module item should either be expression, definition, or EOI"),
+                        _ => unreachable!(
+                            "module item should either be expression, definition, or EOI"
+                        ),
                     }
                 }
 
-                module.defs.extend(defs);
-                module.exprs.extend(exprs);
-                module.pubs.extend(pubs);
-
-                if let Some(last_expr) = compile_repl(module.clone(), field_ops) {
+                if let Some(last_expr) = compile_repl(defs, exprs, pubs, &mut module, field_ops) {
                     println!("Out: {}", last_expr);
                 } else {
                     println!("No expression to evaluate.");
                 }
-                },
-            Err(e) => eprintln!("Parse Error: {:?}", e)
+            }
+            Err(e) => eprintln!("Parse Error: {:?}", e),
         }
     }
 }
 
-
-/* Implements the subcommand that writes witnesses to a JSON file. */
-pub fn halo2_repl_cmd(Halo2 { source }: &Halo2) {
-    println!("** Entering Halo2 Repl");
-    repl_cmd(&source, &Halo2PrimeFieldOps::<Fp>::default());
+pub fn repl(args: &REPL) {
+    match args.field.as_str() {
+        "Halo2" => repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
+        "Plonk" => repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
+        field_str => {
+            if let Ok(_) = field_str.parse::<usize>() {
+                //repl_cmd(&args.source, &fin_field(n))
+                eprintln!("Arbitrary finite fields not implemented");
+            } else {
+                eprintln!("Invalid field value");
+                return;
+            }
+        }
+    };
 }
-
-/* Implements the subcommand that writes circuit into comma separated, three-address file. */
-pub fn plonk_repl_cmd(Plonk { source }: &Plonk) {
-    println!("** Entering Plonk Repl");
-    repl_cmd(&source, &PlonkPrimeFieldOps::<Fr>::default());
-}
-
-pub fn repl(repl_commands: &REPLCommands) {
-    match repl_commands {
-        REPLCommands::Halo2(args) => halo2_repl_cmd(args),
-        REPLCommands::Plonk(args) => plonk_repl_cmd(args),
-    }
-}
-

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -42,15 +42,15 @@ pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) -> Result<()
 
 pub fn repl(args: &REPL) -> Result<(), Error> {
     match args.field.as_str() {
-        "Halo2" | "halo2" => return repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
-        "Plonk" | "plonk" => return repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
+        "Halo2" | "halo2" => repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
+        "Plonk" | "plonk" => repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
         field_str => {
-            if let Ok(_) = field_str.parse::<usize>() {
+            if field_str.parse::<usize>().is_ok() {
                 // This is for arbitrary finite fields described by a number
-                return Err(Error::InvalidField);
+                Err(Error::InvalidField)
             } else {
-                return Err(Error::InvalidField);
+                Err(Error::InvalidField)
             }
         }
-    };
+    }
 }

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -41,8 +41,8 @@ pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
 
 pub fn repl(args: &REPL) {
     match args.field.as_str() {
-        "Halo2" => repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
-        "Plonk" => repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
+        "Halo2" | "halo2" => repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
+        "Plonk" | "plonk" => repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
         field_str => {
             if let Ok(_) = field_str.parse::<usize>() {
                 //repl_cmd(&args.source, &fin_field(n))

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -2,7 +2,6 @@ use crate::pest::Parser;
 
 use crate::ast::{Definition, Module, Rule, TExpr, VampirParser, Variable};
 use crate::transform::{compile_repl, compile, FieldOps};
-//use crate::repl::transform::{compile, evaluate_module, collect_module_variables, FieldOps};
 
 use crate::plonk::synth::PrimeFieldOps as PlonkPrimeFieldOps;
 use ark_bls12_381::Fr;

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -13,8 +13,6 @@ use std::fs;
 use clap::Args;
 use std::path::PathBuf;
 
-use crate::util::Config;
-
 #[derive(Args)]
 pub struct REPL {
     /// Path to source file that is being loaded into repl

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -1,4 +1,5 @@
 use crate::ast::Module;
+use crate::error::Error;
 use crate::transform::{compile_repl, FieldOps};
 
 use crate::plonk::synth::PrimeFieldOps as PlonkPrimeFieldOps;
@@ -24,7 +25,7 @@ pub struct REPL {
     field: String,
 }
 
-pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
+pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) -> Result<(), Error> {
     let mut module: Module = Module::default();
 
     if let Some(path) = source {
@@ -39,17 +40,16 @@ pub fn repl_cmd(source: &Option<PathBuf>, field_ops: &dyn FieldOps) {
     compile_repl(&mut module, field_ops)
 }
 
-pub fn repl(args: &REPL) {
+pub fn repl(args: &REPL) -> Result<(), Error> {
     match args.field.as_str() {
-        "Halo2" | "halo2" => repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
-        "Plonk" | "plonk" => repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
+        "Halo2" | "halo2" => return repl_cmd(&args.source, &Halo2PrimeFieldOps::<Fp>::default()),
+        "Plonk" | "plonk" => return repl_cmd(&args.source, &PlonkPrimeFieldOps::<Fr>::default()),
         field_str => {
             if let Ok(_) = field_str.parse::<usize>() {
-                //repl_cmd(&args.source, &fin_field(n))
-                eprintln!("Arbitrary finite fields not implemented");
+                // This is for arbitrary finite fields described by a number
+                return Err(Error::InvalidField);
             } else {
-                eprintln!("Invalid field value");
-                return;
+                return Err(Error::InvalidField);
             }
         }
     };

--- a/src/repl/cli.rs
+++ b/src/repl/cli.rs
@@ -1,7 +1,7 @@
 use crate::pest::Parser;
 
 use crate::ast::{Definition, Module, Rule, TExpr, VampirParser, Variable};
-use crate::transform::{compile_repl, compile, FieldOps};
+use crate::transform::{compile, compile_repl, FieldOps};
 
 use crate::plonk::synth::PrimeFieldOps as PlonkPrimeFieldOps;
 use ark_bls12_381::Fr;

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,0 +1,1 @@
+pub mod cli;

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -473,7 +473,8 @@ fn evaluate(
                     // next position
                     let param1 = intr.params[intr.pos].clone();
                     intr.pos += 1;
-                    // The specific binding that needs to be added to environment
+                    // The specific binding that needs to be added to
+                    // environment
                     let new_bind = LetBinding(param1, Box::new(*expr2.clone()));
                     // Make sure that the argument's environment does not get
                     // overridden by that of the function by producing
@@ -512,7 +513,8 @@ fn evaluate(
                     // Now that we have an assignment, move the function
                     // parameter into the environment
                     let param1 = fun.params.remove(0);
-                    // The specific binding that needs to be added to environment
+                    // The specific binding that needs to be added to
+                    // environment
                     let new_bind = LetBinding(param1, Box::new(*expr2.clone()));
                     // Make sure that the argument's environment does not get
                     // overridden by that of the function by producing
@@ -727,18 +729,10 @@ fn evaluate(
             Ok(Expr::Constant(field_ops.canonical(c.clone())).type_expr(expr.t.clone()))
         }
         Expr::Unit | Expr::Nil => Ok(expr.clone()),
-        Expr::Variable(var) => {
-            if let Some(val) = bindings.get(&var.id) {
-                if !prover_defs.contains(&var.id) {
-                    let val_clone = val.clone();
-                    evaluate(&val_clone, flattened, bindings, prover_defs, field_ops, gen)
-                } else {
-                    Ok(expr.clone())
-                }
-            } else {
-                Ok(expr.clone())
-            }
-        }
+        Expr::Variable(var) => match bindings.get(&var.id) {
+            Some(val) if !prover_defs.contains(&var.id) => Ok(val.clone()),
+            _ => Ok(expr.clone()),
+        },
         Expr::Function(Function {
             params, body, env, ..
         }) if params.is_empty() => {
@@ -1877,13 +1871,13 @@ pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) -> Result
                     );
 
                     if let Err(e) = res {
-                        println!("Evaluation Error: {e:?}")
+                        println!("Evaluation Error: {:?}", e)
                     } else {
                         println!("Out: {}", res.unwrap())
                     };
                 }
             }
-            Err(e) => eprintln!("Parse Error: {e:?}"),
+            Err(e) => eprintln!("Parse Error: {:?}", e),
         }
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1727,7 +1727,7 @@ fn expand_fold_intrinsic(
 }
 
 /* Version of compile for repl. Does everything compile does to evaluate a module, but split between repl interactions. */
-pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) {
+pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) -> Result<(), Error> {
     let mut vg = VarGen::new();
     let mut globals = HashMap::new();
     let mut bindings = HashMap::new();
@@ -1882,4 +1882,6 @@ pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) {
             Err(e) => eprintln!("Parse Error: {:?}", e),
         }
     }
+
+    return Ok(());
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -473,8 +473,7 @@ fn evaluate(
                     // next position
                     let param1 = intr.params[intr.pos].clone();
                     intr.pos += 1;
-                    // The specific binding that needs to be added to
-                    // environment
+                    // The specific binding that needs to be added to environment
                     let new_bind = LetBinding(param1, Box::new(*expr2.clone()));
                     // Make sure that the argument's environment does not get
                     // overridden by that of the function by producing
@@ -513,8 +512,7 @@ fn evaluate(
                     // Now that we have an assignment, move the function
                     // parameter into the environment
                     let param1 = fun.params.remove(0);
-                    // The specific binding that needs to be added to
-                    // environment
+                    // The specific binding that needs to be added to environment
                     let new_bind = LetBinding(param1, Box::new(*expr2.clone()));
                     // Make sure that the argument's environment does not get
                     // overridden by that of the function by producing
@@ -729,10 +727,18 @@ fn evaluate(
             Ok(Expr::Constant(field_ops.canonical(c.clone())).type_expr(expr.t.clone()))
         }
         Expr::Unit | Expr::Nil => Ok(expr.clone()),
-        Expr::Variable(var) => match bindings.get(&var.id) {
-            Some(val) if !prover_defs.contains(&var.id) => Ok(val.clone()),
-            _ => Ok(expr.clone()),
-        },
+        Expr::Variable(var) => {
+            if let Some(val) = bindings.get(&var.id) {
+                if !prover_defs.contains(&var.id) {
+                    let val_clone = val.clone();
+                    evaluate(&val_clone, flattened, bindings, prover_defs, field_ops, gen)
+                } else {
+                    Ok(expr.clone())
+                }
+            } else {
+                Ok(expr.clone())
+            }
+        }
         Expr::Function(Function {
             params, body, env, ..
         }) if params.is_empty() => {
@@ -1871,13 +1877,13 @@ pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) -> Result
                     );
 
                     if let Err(e) = res {
-                        println!("Evaluation Error: {:?}", e)
+                        println!("Evaluation Error: {e:?}")
                     } else {
                         println!("Out: {}", res.unwrap())
                     };
                 }
             }
-            Err(e) => eprintln!("Parse Error: {:?}", e),
+            Err(e) => eprintln!("Parse Error: {e:?}"),
         }
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1735,39 +1735,42 @@ pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) {
     register_fold_intrinsic(&mut globals, &mut global_types, &mut bindings, &mut vg);
 
     let mut locals = HashMap::new();
-    number_module_variables(&mut module, &mut globals, &mut vg, &mut locals);
-    infer_module_types(
-        &mut module,
-        &globals,
-        &mut global_types,
-        &mut prog_types,
-        &mut vg,
-    );
-    println!("** Inferring types...");
-    print_types(&module, &prog_types, &Config { quiet: false });
-    // Global variables may have further internal structure, determine this
-    // using derived type information
-    expand_global_variables(
-        &mut module,
-        &globals,
-        &global_types,
-        &mut prog_types,
-        &bindings,
-        &mut vg,
-    );
-    // Type information is no longer required since we do symbolic
-    // execution from now on
-    strip_module_types(&mut module);
     let mut prover_defs = HashSet::new();
-    // Start generating arithmetic constraints
-    evaluate_module(
-        &module,
-        &mut None,
-        &mut bindings,
-        &mut prover_defs,
-        field_ops,
-        &mut vg,
-    );
+    if module.defs.len() != 0 || module.exprs.len() != 0 || module.pubs.len() != 0 {
+        number_module_variables(&mut module, &mut globals, &mut vg, &mut locals);
+        infer_module_types(
+            &mut module,
+            &globals,
+            &mut global_types,
+            &mut prog_types,
+            &mut vg,
+        );
+        println!("** Inferring types...");
+        print_types(&module, &prog_types, &Config { quiet: false });
+        // Global variables may have further internal structure, determine this
+        // using derived type information
+        expand_global_variables(
+            &mut module,
+            &globals,
+            &global_types,
+            &mut prog_types,
+            &bindings,
+            &mut vg,
+        );
+        // Type information is no longer required since we do symbolic
+        // execution from now on
+        strip_module_types(&mut module);
+        // Start generating arithmetic constraints
+
+        evaluate_module(
+            &module,
+            &mut None,
+            &mut bindings,
+            &mut prover_defs,
+            field_ops,
+            &mut vg,
+        );
+    }
 
     loop {
         print!("In : ");

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -5,7 +5,6 @@ use crate::ast::{
 use crate::error::*;
 use crate::pest::Parser;
 use crate::qprintln;
-use crate::pest::Parser;
 use crate::typecheck::{
     expand_expr_variables, expand_pattern_variables, infer_module_types, print_types,
     strip_module_types, Type,
@@ -995,7 +994,7 @@ fn flatten_binding(pat: &TPat, expr: &TExpr, oflattened: &mut Option<Module>) {
             (Pat::Cons(pat1, pat2), Expr::Cons(expr1, expr2)) => {
                 flatten_binding(pat1, expr1, oflattened);
                 flatten_binding(pat2, expr2, oflattened);
-            }
+            },
             _ => unreachable!("encountered unexpected binding: {} = {}", pat, expr),
         }
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1739,9 +1739,8 @@ pub fn compile_repl(
 
         println!("** Inferring types...");
         // Only print type of new def.
-        let mut modified_module = module.clone();
-        modified_module.defs = modified_module.defs.split_off(modified_module.defs.len().saturating_sub(def_len));
-        print_types(&modified_module, &prog_types, &Config { quiet: false });
+        let last_n_defs = module.defs.iter().rev().take(def_len).cloned().rev().collect::<Vec<_>>();
+        print_types(&Module { defs: last_n_defs, ..Module::default() }, &prog_types, &Config { quiet: false });
 
         // Global variables may have further internal structure, determine this
         // using derived type information

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1443,7 +1443,7 @@ fn expand_fresh_intrinsic(
                 let val = bindings[&param_var.id].clone();
                 // Make a new prover definition that is equal to the argument
                 let fresh_arg = Variable::new(gen.generate_id());
-                let mut fresh_pat = Pat::Variable(fresh_arg.clone()).type_pat(val.t.clone());
+                let mut fresh_pat = Pat::Variable(fresh_arg).type_pat(val.t.clone());
                 let mut pat_exps = HashMap::new();
                 // Expand the pattern using our knowledge of the expression's form
                 expand_pattern_variables(&mut fresh_pat, &val, &mut pat_exps, gen).expect("Pattern variable expantion shouldn't fail.");

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1730,7 +1730,11 @@ pub fn compile_repl(
         );
 
         println!("** Inferring types...");
+        // Only print type of new def.
+        let mut modified_module = module.clone();
+        modified_module.defs = modified_module.defs.split_off(modified_module.defs.len().saturating_sub(def_len));
         print_types(&module, &prog_types, &Config { quiet: false });
+        // print_types(&module, &prog_types);
 
         // Global variables may have further internal structure, determine this
         // using derived type information

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1733,8 +1733,7 @@ pub fn compile_repl(
         // Only print type of new def.
         let mut modified_module = module.clone();
         modified_module.defs = modified_module.defs.split_off(modified_module.defs.len().saturating_sub(def_len));
-        print_types(&module, &prog_types, &Config { quiet: false });
-        // print_types(&module, &prog_types);
+        print_types(&modified_module, &prog_types, &Config { quiet: false });
 
         // Global variables may have further internal structure, determine this
         // using derived type information

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1874,10 +1874,6 @@ pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) -> Result
                         .unwrap()
                     );
                 }
-
-                if module.exprs.len() == 0 {
-                    println!("No expression to evaluate.")
-                }
             }
             Err(e) => eprintln!("Parse Error: {:?}", e),
         }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1861,18 +1861,20 @@ pub fn compile_repl(mut module: &mut Module, field_ops: &dyn FieldOps) -> Result
                     );
                 }
                 for expr in &module.exprs {
-                    println!(
-                        "Out: {}",
-                        evaluate(
-                            expr,
-                            &mut None,
-                            &mut bindings,
-                            &mut prover_defs,
-                            field_ops,
-                            &mut vg,
-                        )
-                        .unwrap()
+                    let res = evaluate(
+                        expr,
+                        &mut None,
+                        &mut bindings,
+                        &mut prover_defs,
+                        field_ops,
+                        &mut vg,
                     );
+
+                    if let Err(e) = res {
+                        println!("Evaluation Error: {:?}", e)
+                    } else {
+                        println!("Out: {}", res.unwrap())
+                    };
                 }
             }
             Err(e) => eprintln!("Parse Error: {:?}", e),


### PR DESCRIPTION
This implements a repl command allowing one to interact with definitions.

Example usage is:
```
./target/debug/vamp-ir repl -f halo2
```

this will enter into a repl with a blank context using the halo2 field. At this point, one can enter statements the same as they would in a Vamp-IR file. For example;

```
Entering REPL with no module loaded.
In : 1+1;
Out: 2
In : def x = 25;
** Inferring types...
x[9]: int
In : def double x = x + x;
** Inferring types...
double[13]: (int -> int)
In : double x;
Out: 50
```

One can optionally specify a source file to be loaded. For example; 
```
./target/debug/vamp-ir repl -f halo2 -s tests/bool.pir
```

will enter the repl with the definitions from the `tests/bool.pir` file.

- Closes #60.