### PR TITLE
Add json5 support for witness inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand_core = "0.6.3"
 plonk = { git = "https://github.com/ZK-Garage/plonk", rev = "ec76fd36cc6b9e9d0f7a9495094e76b86e53dab4" }
 plonk-core = { git = "https://github.com/ZK-Garage/plonk", rev = "ec76fd36cc6b9e9d0f7a9495094e76b86e53dab4", features = [ "std", "trace", "trace-print" ] }
 serde_json = "1.0.93"
+json5 = "0.4.1"
 
 [[bench]]
 name = "plonk_benches"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    fs::File,
+    fs,
     ops::Neg,
     path::PathBuf,
 };
@@ -22,10 +22,11 @@ where
     F: Num + Neg<Output = F>,
     <F as num_traits::Num>::FromStrRadixErr: std::fmt::Debug,
 {
-    let inputs = File::open(path_to_inputs).expect("Could not open inputs file");
+    let contents = fs::read_to_string(path_to_inputs).expect("Could not read inputs file");
 
     // Read the user-supplied inputs from the file
-    let named_assignments: HashMap<String, String> = serde_json::from_reader(inputs).unwrap();
+    let named_assignments: HashMap<String, String> =
+        json5::from_str(&contents).expect("Could not parse JSON5");
 
     // Get the expected inputs from the circuit module
     let mut input_variables = HashMap::new();


### PR DESCRIPTION
This allows json files to be in the json5 format. As an example, if the file `bool.json` has the following contents;
```
{
  // comments
  "a": "0"
}
```
then the command
```
./target/debug/vamp-ir halo2 compile -s tests/bool.pir -o circuit.halo2
./target/debug/vamp-ir halo2 prove -c circuit.halo2 -o proof.halo2 -i tests/bool.json
```
will now succeed where it would previously give a parsing error.

- Closes #103 