### PR TITLE
Add halo2 proof and verify API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,12 @@ pub enum Error {
     // general error from backend
     BackendError { e: String },
 
+    // The user did not provide an assignment for a variable during proving
+    MissingVariableAssignment { var_name: String },
+
+    // A variable assignment has an invalid value
+    InvalidVariableAssignmentValue { var_name: String },
+
     // proof fails to verify
     ProofVerificationFailure,
 
@@ -193,7 +199,12 @@ impl std::fmt::Display for Error {
 
             // invalid field at repl
             Self::InvalidField => write!(f, "Invalid field value"),
-            Error::ParseError { e } => write!(f, "Error while parsing file: {e}"),
+
+            Self::ParseError { e } => write!(f, "Error while parsing file: {e}"),
+
+            Self::MissingVariableAssignment { var_name } => write!(f, "Missing assignment for variable: {var_name}"),
+
+            Self::InvalidVariableAssignmentValue { var_name } => write!(f, "The assignment for variable: {var_name} has an invalid value")
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -202,9 +202,14 @@ impl std::fmt::Display for Error {
 
             Self::ParseError { e } => write!(f, "Error while parsing file: {e}"),
 
-            Self::MissingVariableAssignment { var_name } => write!(f, "Missing assignment for variable: {var_name}"),
+            Self::MissingVariableAssignment { var_name } => {
+                write!(f, "Missing assignment for variable: {var_name}")
+            }
 
-            Self::InvalidVariableAssignmentValue { var_name } => write!(f, "The assignment for variable: {var_name} has an invalid value")
+            Self::InvalidVariableAssignmentValue { var_name } => write!(
+                f,
+                "The assignment for variable: {var_name} has an invalid value"
+            ),
         }
     }
 }

--- a/src/halo2/api.rs
+++ b/src/halo2/api.rs
@@ -203,7 +203,7 @@ mod tests {
     #[ignore] // This test panics in type checking
     fn test_compile_type_error() {
         let config = Config { quiet: true };
-        assert!(compile("1/0 = 1;", &config).is_err());
+        assert!(compile("(1, 2) = 1;", &config).is_err());
     }
 
     #[test]

--- a/src/halo2/api.rs
+++ b/src/halo2/api.rs
@@ -150,4 +150,28 @@ mod tests {
         let config = Config { quiet: true };
         assert!(compile("1/0 = 1;", &config).is_err());
     }
+
+    #[test]
+    fn test_prove_valid() {
+        let config = Config { quiet: true };
+        let circuit = compile("x = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::one())]);
+        assert!(prove(&circuit, &assignments, &config).is_ok());
+    }
+
+    #[test]
+    fn test_prove_missing_assignment() {
+        let config = Config { quiet: true };
+        let circuit = compile("x = 1;", &config).unwrap();
+        let assignments: HashMap<String, Fp> = HashMap::new();
+        assert!(prove(&circuit, &assignments, &config).is_err());
+    }
+
+    #[test]
+    fn test_prove_invalid_assignment() {
+        let config = Config { quiet: true };
+        let circuit = compile("x = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::zero())]);
+        assert!(prove(&circuit, &assignments, &config).is_ok());
+    }
 }

--- a/src/halo2/api.rs
+++ b/src/halo2/api.rs
@@ -1,15 +1,16 @@
 use crate::ast::{Module, VariableId};
 use crate::error::Error;
-use crate::error::Error::{BackendError, ParseError};
-use crate::halo2::synth::make_constant;
+use crate::error::Error::{BackendError, ParseError, ProofVerificationFailure};
 use crate::halo2::synth::{keygen, prover, Halo2Module, PrimeFieldOps};
+use crate::halo2::synth::{make_constant, verifier};
 use crate::qprintln;
-use crate::util::{get_circuit_assignments, Config};
+use crate::util::{get_circuit_assignments, get_public_circuit_assignments, Config};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_serialize::{Read, SerializationError};
 use bincode::error::{DecodeError, EncodeError};
 use ff::PrimeField;
 use halo2_proofs::pasta::{EqAffine, Fp};
+use halo2_proofs::plonk::keygen_vk;
 use halo2_proofs::poly::commitment::Params;
 use num_bigint::BigInt;
 use std::collections::HashMap;
@@ -19,7 +20,7 @@ use std::rc::Rc;
 pub fn compile(source: impl AsRef<str>, config: &Config) -> Result<HaloCircuitData, Error> {
     qprintln!(config, "* Compiling constraints...");
     let module = Module::parse(source.as_ref()).map_err(|err| ParseError { e: err.to_string() })?;
-    let module_3ac = crate::transform::compile(module, &PrimeFieldOps::<Fp>::default(), &config);
+    let module_3ac = crate::transform::compile(module, &PrimeFieldOps::<Fp>::default(), config);
     qprintln!(config, "* Synthesizing arithmetic circuit...");
     let module_rc = Rc::new(module_3ac);
     let circuit = Halo2Module::<Fp>::new(module_rc);
@@ -34,12 +35,53 @@ pub fn prove(
 ) -> Result<ProofDataHalo2, Error> {
     let module = circuit_data.circuit.module.as_ref();
     let named_string_assignments: HashMap<String, Fp> = named_assignments
-        .into_iter()
+        .iter()
         .map(|(key, value)| (key.as_ref().to_string(), *value))
         .collect();
     let assignments = get_circuit_assignments(module, &named_string_assignments)?;
     let proof_data = prove_from_variable_assignments(circuit_data, &assignments, config)?;
     Ok(ProofDataHalo2::from_proof_data_cli_halo2(proof_data))
+}
+
+pub fn verify(
+    circuit_data: &HaloCircuitData,
+    proof_data: &ProofDataHalo2,
+    named_public_assignments: &HashMap<impl AsRef<str>, Fp>,
+    _config: &Config,
+) -> Result<(), Error> {
+    let circuit = &circuit_data.circuit;
+    let params = &circuit_data.params;
+    let module = circuit.module.as_ref();
+    let named_public_string_assignments: HashMap<String, Fp> = named_public_assignments
+        .iter()
+        .map(|(key, value)| (key.as_ref().to_string(), *value))
+        .collect();
+    let public_input = public_inputs_from_assignments(module, &named_public_string_assignments)?;
+    let vk = keygen_vk(params, circuit)?;
+    verifier(params, &vk, &proof_data.proof, public_input.as_slice())
+        .map_err(|_| ProofVerificationFailure)
+}
+
+fn public_inputs_from_variable_assignments(
+    module: &Module,
+    public_assignments: &HashMap<VariableId, Fp>,
+) -> Vec<Fp> {
+    module
+        .pubs
+        .iter()
+        .map(|inst| public_assignments[&inst.id])
+        .collect::<Vec<Fp>>()
+}
+
+fn public_inputs_from_assignments(
+    module: &Module,
+    assignments: &HashMap<String, Fp>,
+) -> Result<Vec<Fp>, Error> {
+    let var_assignments = get_public_circuit_assignments(module, assignments)?;
+    Ok(public_inputs_from_variable_assignments(
+        module,
+        &var_assignments,
+    ))
 }
 
 pub(crate) fn prove_from_int_variable_assignments(
@@ -67,11 +109,7 @@ pub(crate) fn prove_from_variable_assignments(
     circuit.populate_variables(assignments.clone());
 
     // Get public inputs Fp
-    let binding = module
-        .pubs
-        .iter()
-        .map(|inst| assignments[&inst.id])
-        .collect::<Vec<Fp>>();
+    let binding = public_inputs_from_variable_assignments(module, assignments);
     let instances = binding.as_slice();
 
     let public_inputs: Vec<u8> = instances
@@ -84,11 +122,11 @@ pub(crate) fn prove_from_variable_assignments(
 
     // Generating proving key
     qprintln!(config, "* Generating proving key...");
-    let (pk, _vk) = keygen(&circuit, &params)?;
+    let (pk, _vk) = keygen(&circuit, params)?;
 
     // Start proving witnesses
     qprintln!(config, "* Proving knowledge of witnesses...");
-    let proof = prover(circuit.clone(), &params, &pk, instances)
+    let proof = prover(circuit.clone(), params, &pk, instances)
         .map_err(|e| BackendError { e: e.to_string() })?;
     Ok(ProofDataCliHalo2 {
         proof,
@@ -190,5 +228,54 @@ mod tests {
         let circuit = compile("x = 1;", &config).unwrap();
         let assignments = HashMap::from([("x", Fp::zero())]);
         assert!(prove(&circuit, &assignments, &config).is_ok());
+    }
+
+    #[test]
+    fn test_verify_valid_no_public() {
+        let config = Config { quiet: true };
+        let circuit = compile("x = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::one())]);
+        let proof_data = prove(&circuit, &assignments, &config).unwrap();
+        assert!(verify(&circuit, &proof_data, &assignments, &config).is_ok());
+    }
+
+    #[test]
+    fn test_verify_valid_with_public() {
+        let config = Config { quiet: true };
+        let circuit = compile("pub x; pub y; x + y + z = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::one()), ("y", Fp::zero()), ("z", Fp::zero())]);
+        let public_assignments = HashMap::from([("x", Fp::one()), ("y", Fp::zero())]);
+        let proof_data = prove(&circuit, &assignments, &config).unwrap();
+        assert!(verify(&circuit, &proof_data, &public_assignments, &config).is_ok());
+    }
+
+    #[test]
+    fn test_verify_invalid_input_no_public() {
+        let config = Config { quiet: true };
+        let circuit = compile("x = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::zero())]);
+        let public_assignments: HashMap<String, Fp> = HashMap::new();
+        let proof_data = prove(&circuit, &assignments, &config).unwrap();
+        assert!(verify(&circuit, &proof_data, &public_assignments, &config).is_err());
+    }
+
+    #[test]
+    fn test_verify_valid_input_invalid_public_input() {
+        let config = Config { quiet: true };
+        let circuit = compile("pub x; x = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::one())]);
+        let public_assignments = HashMap::from([("x", Fp::zero())]);
+        let proof_data = prove(&circuit, &assignments, &config).unwrap();
+        assert!(verify(&circuit, &proof_data, &public_assignments, &config).is_err());
+    }
+
+    #[test]
+    fn test_verify_valid_input_missing_public_input() {
+        let config = Config { quiet: true };
+        let circuit = compile("pub x; x = 1;", &config).unwrap();
+        let assignments = HashMap::from([("x", Fp::one())]);
+        let public_assignments: HashMap<String, Fp> = HashMap::new();
+        let proof_data = prove(&circuit, &assignments, &config).unwrap();
+        assert!(verify(&circuit, &proof_data, &public_assignments, &config).is_err());
     }
 }

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -3,7 +3,7 @@ use crate::halo2::api::{prove_from_int_variable_assignments, ProofDataHalo2};
 use crate::halo2::synth::verifier;
 
 use crate::qprintln;
-use crate::util::{get_circuit_assignments, prompt_inputs, read_inputs_from_file2, Config};
+use crate::util::{get_circuit_assignments, prompt_inputs, read_inputs_from_file, Config};
 
 use halo2_proofs::plonk::keygen_vk;
 
@@ -90,7 +90,7 @@ fn prove_from_file(
         "* Reading inputs from file {}...",
         path_to_inputs.to_string_lossy()
     );
-    let raw_inputs: HashMap<String, BigInt> = read_inputs_from_file2(path_to_inputs).unwrap();
+    let raw_inputs: HashMap<String, BigInt> = read_inputs_from_file(path_to_inputs).unwrap();
     let inputs =
         get_circuit_assignments::<BigInt>(circuit_data.circuit.module.deref(), &raw_inputs)?;
     prove_from_int_variable_assignments(circuit_data, &inputs, config)

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::halo2::api::{prove_from_int_variable_assignments, ProofDataHalo2};
+use crate::halo2::api::{prove_from_int_variable_assignments, ProofDataCliHalo2};
 use crate::halo2::synth::verifier;
 
 use crate::qprintln;
@@ -84,7 +84,7 @@ fn prove_from_file(
     path_to_inputs: &PathBuf,
     circuit_data: &HaloCircuitData,
     config: &Config,
-) -> Result<ProofDataHalo2, Error> {
+) -> Result<ProofDataCliHalo2, Error> {
     qprintln!(
         config,
         "* Reading inputs from file {}...",
@@ -153,10 +153,10 @@ fn verify_halo2_cmd(
 
     qprintln!(config, "* Reading zero-knowledge proof...");
     let mut proof_file = File::open(proof).expect("unable to load proof file");
-    let ProofDataHalo2 {
+    let ProofDataCliHalo2 {
         proof,
         public_inputs,
-    } = ProofDataHalo2::deserialize(&mut proof_file).unwrap();
+    } = ProofDataCliHalo2::deserialize(&mut proof_file).unwrap();
 
     let instances_vec: Vec<Fp> = public_inputs
         .chunks(32)

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -107,7 +107,7 @@ fn prove_halo2_cmd(
                 "* Reading inputs from file {}...",
                 path_to_inputs.to_string_lossy()
             );
-            read_inputs_from_file(&circuit.module, path_to_inputs)
+            read_inputs_from_file(&circuit.module, path_to_inputs).unwrap()
         }
         None => {
             if expected_path_to_inputs.exists() {
@@ -116,7 +116,7 @@ fn prove_halo2_cmd(
                     "* Reading inputs from file {}...",
                     expected_path_to_inputs.to_string_lossy()
                 );
-                read_inputs_from_file(&circuit.module, &expected_path_to_inputs)
+                read_inputs_from_file(&circuit.module, &expected_path_to_inputs).unwrap()
             } else {
                 qprintln!(config, "* Soliciting circuit witnesses...");
                 prompt_inputs(&circuit.module)

--- a/src/halo2/cli.rs
+++ b/src/halo2/cli.rs
@@ -71,7 +71,7 @@ fn compile_halo2_cmd(
     config: &Config,
 ) -> Result<(), Error> {
     let source = fs::read_to_string(source).expect("cannot read file");
-    let halo_circuit_data = crate::halo2::api::compile(source, &config)?;
+    let halo_circuit_data = crate::halo2::api::compile(source, config)?;
     let mut circuit_file = File::create(output).expect("unable to create circuit file");
     halo_circuit_data.write(&mut circuit_file).unwrap();
 

--- a/src/plonk/cli.rs
+++ b/src/plonk/cli.rs
@@ -264,7 +264,7 @@ fn prove_plonk_cmd(
                 "* Reading inputs from file {}...",
                 path_to_inputs.to_string_lossy()
             );
-            read_inputs_from_file(&circuit.module, path_to_inputs)
+            read_inputs_from_file(&circuit.module, path_to_inputs).unwrap()
         }
         None => {
             if expected_path_to_inputs.exists() {
@@ -273,7 +273,7 @@ fn prove_plonk_cmd(
                     "* Reading inputs from file {}...",
                     expected_path_to_inputs.to_string_lossy()
                 );
-                read_inputs_from_file(&circuit.module, &expected_path_to_inputs)
+                read_inputs_from_file(&circuit.module, &expected_path_to_inputs).unwrap()
             } else {
                 qprintln!(config, "* Soliciting circuit witnesses...");
                 prompt_inputs(&circuit.module)

--- a/src/plonk/cli.rs
+++ b/src/plonk/cli.rs
@@ -1,9 +1,9 @@
-use crate::ast::Module;
+use crate::ast::{Module, VariableId};
 use crate::error::Error;
 use crate::plonk::synth::{make_constant, PlonkModule, PrimeFieldOps};
 use crate::qprintln;
 use crate::transform::compile;
-use crate::util::{prompt_inputs, read_inputs_from_file, Config};
+use crate::util::{get_circuit_assignments, prompt_inputs, read_inputs_from_file, Config};
 
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ec::PairingEngine;
@@ -23,10 +23,12 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
+
 use std::path::PathBuf;
 use std::rc::Rc;
 
 use clap::{Args, Subcommand};
+use num_bigint::BigInt;
 
 type PC = SonicKZG10<Bls12_381, DensePolynomial<BlsScalar>>;
 type UniversalParams = <PC as PolynomialCommitment<
@@ -232,6 +234,20 @@ fn compile_plonk_cmd(
     Ok(())
 }
 
+fn inputs_from_file(
+    path_to_inputs: &PathBuf,
+    circuit_module: &Module,
+    config: &Config,
+) -> Result<HashMap<VariableId, BigInt>, Error> {
+    qprintln!(
+        config,
+        "* Reading inputs from file {}...",
+        path_to_inputs.to_string_lossy()
+    );
+    let raw_inputs: HashMap<String, BigInt> = read_inputs_from_file(path_to_inputs).unwrap();
+    get_circuit_assignments::<BigInt>(circuit_module, &raw_inputs)
+}
+
 /* Implements the subcommand that creates a proof from interactively entered
  * inputs. */
 fn prove_plonk_cmd(
@@ -258,28 +274,16 @@ fn prove_plonk_cmd(
 
     // Prompt for program inputs
     let var_assignments_ints = match inputs {
-        Some(path_to_inputs) => {
-            qprintln!(
-                config,
-                "* Reading inputs from file {}...",
-                path_to_inputs.to_string_lossy()
-            );
-            read_inputs_from_file(&circuit.module, path_to_inputs).unwrap()
-        }
+        Some(path_to_inputs) => inputs_from_file(path_to_inputs, &circuit.module, config),
         None => {
             if expected_path_to_inputs.exists() {
-                qprintln!(
-                    config,
-                    "* Reading inputs from file {}...",
-                    expected_path_to_inputs.to_string_lossy()
-                );
-                read_inputs_from_file(&circuit.module, &expected_path_to_inputs).unwrap()
+                inputs_from_file(&expected_path_to_inputs, &circuit.module, config)
             } else {
                 qprintln!(config, "* Soliciting circuit witnesses...");
-                prompt_inputs(&circuit.module)
+                Ok(prompt_inputs(&circuit.module))
             }
         }
-    };
+    }?;
 
     let mut var_assignments = HashMap::new();
     for (k, v) in var_assignments_ints {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -903,10 +903,15 @@ fn collect_def_variables(def: &Definition, map: &mut HashMap<VariableId, Variabl
     collect_pattern_variables(&def.0 .0, map);
 }
 
-/* Collect all the variables occurring in the given module. */
-pub fn collect_module_variables(module: &Module, map: &mut HashMap<VariableId, Variable>) {
+/* Collect all the public variables occurring in the given module. */
+pub fn collect_public_module_variables(module: &Module, map: &mut HashMap<VariableId, Variable>) {
     map.reserve(module.pubs.len());
     map.extend(module.pubs.iter().map(|var| (var.id, var.clone())));
+}
+
+/* Collect all the variables occurring in the given module. */
+pub fn collect_module_variables(module: &Module, map: &mut HashMap<VariableId, Variable>) {
+    collect_public_module_variables(module, map);
 
     for def in &module.defs {
         collect_def_variables(def, map);

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,10 +12,48 @@ use num_traits::Num;
 use crate::ast::Variable;
 use crate::error::Error;
 use crate::error::Error::{InvalidVariableAssignmentValue, MissingVariableAssignment};
+use crate::transform::collect_public_module_variables;
 use crate::{
     ast::{Module, Pat, VariableId},
     transform::collect_module_variables,
 };
+
+/// Find a value for each expected variable from among the named assignments.
+fn translate_named_assignments<T>(
+    expected_variables: &HashMap<VariableId, Variable>,
+    named_assignments: &HashMap<String, T>,
+) -> Result<HashMap<VariableId, T>, Error>
+where
+    T: Clone,
+{
+    expected_variables
+        .iter()
+        .filter_map(|(id, expected_var)| {
+            expected_var.name.as_deref().map(|var_name| {
+                named_assignments
+                    .get(var_name)
+                    .cloned()
+                    .ok_or_else(|| MissingVariableAssignment {
+                        var_name: var_name.to_string(),
+                    })
+                    .map(|assignment| (*id, assignment))
+            })
+        })
+        .collect()
+}
+
+/// Convert named circuit assignments for public variables to assignments of vamp-ir variableIds.
+pub(crate) fn get_public_circuit_assignments<T>(
+    module: &Module,
+    named_assignments: &HashMap<String, T>,
+) -> Result<HashMap<VariableId, T>, Error>
+where
+    T: Clone,
+{
+    let mut input_variables = HashMap::new();
+    collect_public_module_variables(module, &mut input_variables);
+    translate_named_assignments(&input_variables, named_assignments)
+}
 
 /// Convert named circuit assignments to assignments of vamp-ir variableIds.
 /// Useful for calling vamp-ir Halo2Module::populate_variable_assignments.
@@ -34,21 +72,7 @@ where
             input_variables.remove(&var.id);
         }
     }
-
-    input_variables
-        .iter()
-        .filter_map(|(id, expected_var)| {
-            expected_var.name.as_deref().map(|var_name| {
-                named_assignments
-                    .get(var_name)
-                    .cloned()
-                    .ok_or_else(|| MissingVariableAssignment {
-                        var_name: var_name.to_string(),
-                    })
-                    .map(|assignment| (*id, assignment))
-            })
-        })
-        .collect()
+    translate_named_assignments(&input_variables, named_assignments)
 }
 
 /* Read satisfying inputs to the given program from a file. */
@@ -71,7 +95,7 @@ where
                     var_name: var_name.clone(),
                 }
             })?;
-            Ok((var_name.clone(), n))
+            Ok((var_name, n))
         })
         .collect::<Result<HashMap<String, F>, Error>>()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use ark_serialize::Write;
+
 use num_traits::Num;
 
 use crate::ast::Variable;
@@ -51,7 +52,7 @@ where
 }
 
 /* Read satisfying inputs to the given program from a file. */
-pub fn read_inputs_from_file2<F>(path_to_inputs: &PathBuf) -> Result<HashMap<String, F>, Error>
+pub fn read_inputs_from_file<F>(path_to_inputs: &PathBuf) -> Result<HashMap<String, F>, Error>
 where
     F: Clone + Num + Neg<Output = F>,
     <F as num_traits::Num>::FromStrRadixErr: std::fmt::Debug,
@@ -73,35 +74,6 @@ where
             Ok((var_name.clone(), n))
         })
         .collect::<Result<HashMap<String, F>, Error>>()
-}
-
-/* Read satisfying inputs to the given program from a file. */
-pub fn read_inputs_from_file<F>(
-    annotated: &Module,
-    path_to_inputs: &PathBuf,
-) -> Result<HashMap<VariableId, F>, Error>
-where
-    F: Clone + Num + Neg<Output = F>,
-    <F as num_traits::Num>::FromStrRadixErr: std::fmt::Debug,
-{
-    let contents = fs::read_to_string(path_to_inputs).expect("Could not read inputs file");
-
-    // Read the user-supplied inputs from the file
-    let named_assignments: HashMap<String, String> =
-        json5::from_str(&contents).expect("Could not parse JSON5");
-
-    let fp_named_assignments: HashMap<String, F> = named_assignments
-        .into_iter()
-        .map(|(var_name, str_value)| {
-            let n = parse_prefixed_num::<F>(&str_value).map_err(|_| {
-                InvalidVariableAssignmentValue {
-                    var_name: var_name.clone(),
-                }
-            })?;
-            Ok((var_name.clone(), n))
-        })
-        .collect::<Result<HashMap<String, F>, Error>>()?;
-    get_circuit_assignments(annotated, &fp_named_assignments)
 }
 
 /* Prompt for satisfying inputs to the given program. */

--- a/src/util.rs
+++ b/src/util.rs
@@ -67,16 +67,14 @@ where
 
     let fp_named_assignments: HashMap<String, F> = named_assignments
         .into_iter()
-        .map(
-            |(var_name, str_value)| {
-                let n = parse_prefixed_num::<F>(&str_value).map_err(|_| {
-                    InvalidVariableAssignmentValue {
-                        var_name: var_name.clone(),
-                    }
-                })?;
-                Ok((var_name.clone(), n))
-            },
-        )
+        .map(|(var_name, str_value)| {
+            let n = parse_prefixed_num::<F>(&str_value).map_err(|_| {
+                InvalidVariableAssignmentValue {
+                    var_name: var_name.clone(),
+                }
+            })?;
+            Ok((var_name.clone(), n))
+        })
         .collect::<Result<HashMap<String, F>, Error>>()?;
     get_circuit_assignments(annotated, &fp_named_assignments)
 }


### PR DESCRIPTION
This PR adds API for prove and verify

```
pub fn prove(
    circuit_data: &HaloCircuitData,
    named_assignments: &HashMap<impl AsRef<str>, Fp>,
    config: &Config,
) -> Result<ProofDataHalo2, Error>
```

```
pub fn verify(
    proof_data: &ProofDataHalo2,
    named_public_assignments: &HashMap<impl AsRef<str>, Fp>,
    _config: &Config,
) -> Result<(), Error>
```

The `prove` API returns `ProofDataHalo2` does not contain the public inputs or the circuit, it does contain the verifyingkey.

```
pub struct ProofDataHalo2 {
    pub proof: Vec<u8>,
    pub verifying_key: VerifyingKey<EqAffine>,
    pub public_fields: Vec<String>,
    pub params: Params<EqAffine>,
}
```

This does not affect the prove CLI, which still writes out the public inputs within the proof file.

Callers of the `verify` API must provide the proof_data and the public assignments. The `public_fields` field is used to pass the public instances in the correct order to the halo2 verify API.