### PR TITLE
Increase maximum iteration count

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1578,7 +1578,7 @@ fn expand_iter_intrinsic(
             } else {
                 return Err(Error::NonConstantIterArgumentError);
             };
-            for _ in 0..val.to_i8().expect("specified iteration count is too large") {
+            for _ in 0..val.to_u16().expect("specified iteration count is too large") {
                 body = TExpr {
                     v: Expr::Application(Box::new(iter_func.clone()), Box::new(body.clone())),
                     t: body.t,


### PR DESCRIPTION
Closes #116 

I don't see a reason to artificially limit the iteration count. It works without the restriction.
