### PR TITLE
Fix benchmarks

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -67,6 +67,17 @@ jobs:
         if: success()
         run: cargo build --release --target=${{ matrix.target }}
 
+      - name: benchmarks
+        if: matrix.arch == 'x86_64-musl'
+        run: cargo bench
+
+      - name: upload benchmark output
+        if: matrix.arch == 'x86_64-musl'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bench-results
+          path: benches/halo2_bench_timing.txt
+
   test-macos:
     strategy:
       matrix:

--- a/benches/halo2_benches.rs
+++ b/benches/halo2_benches.rs
@@ -98,7 +98,8 @@ fn bench(pir_file: &str) {
     // Start proving witnesses
     println!("* Proving knowledge of witnesses...");
     let inst10 = Instant::now();
-    let proof = prover(circuit.clone(), &params, &pk, &[]).expect("prover failed in halo2 benchmark");
+    let proof =
+        prover(circuit.clone(), &params, &pk, &[]).expect("prover failed in halo2 benchmark");
     let inst11 = Instant::now();
     file.write_all(
         format!(

--- a/benches/halo2_benches.rs
+++ b/benches/halo2_benches.rs
@@ -98,7 +98,7 @@ fn bench(pir_file: &str) {
     // Start proving witnesses
     println!("* Proving knowledge of witnesses...");
     let inst10 = Instant::now();
-    let proof = prover(circuit.clone(), &params, &pk).expect("prover failed in halo2 benchmark");
+    let proof = prover(circuit.clone(), &params, &pk, &[]).expect("prover failed in halo2 benchmark");
     let inst11 = Instant::now();
     file.write_all(
         format!(
@@ -125,7 +125,7 @@ fn bench(pir_file: &str) {
 
     println!("* Verifying proof validity...");
     let inst14 = Instant::now();
-    let verifier_result = verifier(&params, &vk, &proof);
+    let verifier_result = verifier(&params, &vk, &proof, &[]);
     let inst15 = Instant::now();
     file.write_all(
         format!(


### PR DESCRIPTION
This PR fixes the benchmark code so it now compiles.

`cargo bench` is now run as part of the GitHub build so we know that it continues to work in future. The product of the benchmark run, the timings file, is published as an artefact of the build.