### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ an 11th Gen Intel® Core™ i5-1135G7 @ 2.40GHz × 8 unless stated otherwise
 
 |         | `Compile`  | `Prove`         | `Verify` |
 |:--------|:-----------|:----------------|:---------|
-| Vamp-IR | `729.47 s` | Memory Failiure | X        |
+| Vamp-IR | `729.47 s` | Memory Failure | X        |
 | Halo2   | //         | `160.36 s`      | `1.03 s` |
 
 We re-run the with a device that has 128GB of RAM and these are the results:

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1168,7 +1168,7 @@ enum Usage {
 pub fn classify_defs(omodule: &mut Option<Module>, prover_defs: &mut HashSet<VariableId>) {
     if let Some(module) = omodule {
         let mut classifier = HashMap::new();
-        // Start by assuming that all variables occuring in constraint expressions
+        // Start by assuming that all variables occurring in constraint expressions
         // have constraint definitions.
         for expr in &module.exprs {
             let mut constraint_vars = HashMap::new();


### PR DESCRIPTION
### Title: Fix Typos in `README.md` and `transform.rs`

### Description:
This pull request addresses minor typos in two files:

1. **`README.md`**: Corrected the spelling of "Memory Failiure" to "Memory Failure."
2. **`src/transform.rs`**: Fixed the spelling of "occuring" to "occurring."

These changes improve the clarity and correctness of the documentation and code comments.
